### PR TITLE
[codex] add azure dev deployment automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 ﻿# Environment Variables for Docker Compose
 
-# Google Gemini API Key for AI Analysis
+# Google API key used by Planner.API and Planner.AI in docker-compose
 # Get your API key from: https://makersuite.google.com/app/apikey
-GEMINI_API_KEY=your_gemini_api_key_here
+GOOGLE_API_KEY=your_google_api_key_here
 
 # Firebase Credentials Path
 # Download your Firebase service account JSON from Firebase Console

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -1,12 +1,14 @@
 # CI/CD Overview
 
 This repository uses separate workflows for database and application deployment.
+The Azure dev deployment is bootstrapped by Bicep and scripts under `infra/` and `scripts/azure/`.
 
 ## Dev environment
 
 - `db-migrator-dev.yml`
-  - Applies EF Core migrations
-  - Executes SQL seed scripts
+  - Builds/pushes the `Planner.Tools.DbMigrator` container image to ACR
+  - Runs the Azure Container Apps migration job
+  - Runs the Azure Container Apps seed job when requested
   - Mutates Azure SQL (dev) only
 
 - `deploy-planner-api-aca.yml`
@@ -18,9 +20,16 @@ This repository uses separate workflows for database and application deployment.
   - Builds and pushes the `Planner.Optimization.Worker` container image to ACR
   - Deploys/updates the worker to Azure Container Apps (dev)
 
+- `deploy-planner-ai-worker.yml`
+  - Builds and pushes the `Planner.AI` container image to ACR
+  - Deploys/updates the AI worker to Azure Container Apps (dev)
+
 - `main_planner-blazor-dev.yml`
   - Builds/publishes `Planner.BlazorApp`
   - Deploys to Azure App Service (dev)
 
 The API never performs schema migration or data seeding at runtime.
 All database changes are explicit and executed via DbMigrator.
+
+GitHub Actions uses OIDC against the `dev` environment. Runtime settings and secrets live in Azure Key Vault;
+GitHub stores only `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID` as environment secrets.

--- a/.github/workflows/db-migrator-dev.yml
+++ b/.github/workflows/db-migrator-dev.yml
@@ -2,6 +2,16 @@ name: Database Migrate & Seed (dev)
 
 on:
   workflow_dispatch:
+    inputs:
+      command:
+        description: 'Database command to run'
+        required: true
+        default: 'migrate-and-seed'
+        type: choice
+        options:
+          - migrate-and-seed
+          - migrate
+          - seed
   push:
     branches:
       - main
@@ -15,6 +25,18 @@ on:
       - 'Directory.Build.props'
       - 'Directory.Build.targets'
       - 'global.json'
+      - '.github/workflows/db-migrator-dev.yml'
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AZURE_CONTAINER_REGISTRY: ${{ vars.AZURE_CONTAINER_REGISTRY }}
+  AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+  AZURE_DB_MIGRATE_JOB_NAME: ${{ vars.AZURE_DB_MIGRATE_JOB_NAME }}
+  AZURE_DB_SEED_JOB_NAME: ${{ vars.AZURE_DB_SEED_JOB_NAME }}
+  IMAGE_NAME: planner-db-migrator
 
 jobs:
   migrate-and-seed:
@@ -25,44 +47,106 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
         with:
-          dotnet-version: '10.0.x'
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Restore DbMigrator
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ACR (OIDC)
         run: |
-          dotnet restore tools/Planner.Tools.DbMigrator/Planner.Tools.DbMigrator.csproj
+          az acr login --name $(echo "${AZURE_CONTAINER_REGISTRY}" | cut -d'.' -f1)
 
-      - name: Build DbMigrator
-        run: |
-          dotnet build tools/Planner.Tools.DbMigrator/Planner.Tools.DbMigrator.csproj \
-            --configuration Release \
-            --no-restore
+      - name: Build and push DbMigrator image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: tools/Planner.Tools.DbMigrator/Dockerfile
+          push: true
+          tags: |
+            ${{ env.AZURE_CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.AZURE_CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
-      - name: Safety check – dev database only
+      - name: Install Azure Container Apps extension
+        uses: azure/CLI@v2
+        with:
+          inlineScript: |
+            az extension add --name containerapp --upgrade
+
+      - name: Run DbMigrator jobs
+        uses: azure/CLI@v2
         env:
-          ConnectionStrings__PlannerDb: ${{ secrets.AZURE_SQL_CONNECTION_STRING }}
-        run: |
-          echo "Checking database target..."
-          echo "$ConnectionStrings__PlannerDb" | grep -qi "dev" || \
-            (echo "Refusing to run against non-dev database" && exit 1)
+          DB_COMMAND: ${{ github.event.inputs.command || 'migrate-and-seed' }}
+        with:
+          inlineScript: |
+            set -eo pipefail
 
-      - name: Run EF Core migrations (dev)
-        env:
-          ConnectionStrings__PlannerDb: ${{ secrets.AZURE_SQL_CONNECTION_STRING }}
-        run: |
-          dotnet run \
-            --project tools/Planner.Tools.DbMigrator/Planner.Tools.DbMigrator.csproj \
-            --configuration Release \
-            -- migrate
+            IMAGE_TAG="${AZURE_CONTAINER_REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}"
 
-      - name: Run SQL seed scripts (dev)
-        env:
-          ConnectionStrings__PlannerDb: ${{ secrets.AZURE_SQL_CONNECTION_STRING }}
-        run: |
-          dotnet run \
-            --project tools/Planner.Tools.DbMigrator/Planner.Tools.DbMigrator.csproj \
-            --configuration Release \
-            -- seed
+            wait_for_job() {
+              local job_name="$1"
+              local execution_name="$2"
 
+              for attempt in $(seq 1 120); do
+                status="$(az containerapp job execution show \
+                  --name "$job_name" \
+                  --resource-group "$AZURE_RESOURCE_GROUP" \
+                  --job-execution-name "$execution_name" \
+                  --query properties.status \
+                  -o tsv)"
+
+                echo "$job_name/$execution_name status: $status"
+
+                if [ "$status" = "Succeeded" ]; then
+                  return 0
+                fi
+
+                if [ "$status" = "Failed" ] || [ "$status" = "Canceled" ]; then
+                  return 1
+                fi
+
+                sleep 15
+              done
+
+              echo "Timed out waiting for $job_name/$execution_name"
+              return 1
+            }
+
+            run_job() {
+              local job_name="$1"
+              az containerapp job update \
+                --name "$job_name" \
+                --resource-group "$AZURE_RESOURCE_GROUP" \
+                --image "$IMAGE_TAG" \
+                >/dev/null
+
+              execution_name="$(az containerapp job start \
+                --name "$job_name" \
+                --resource-group "$AZURE_RESOURCE_GROUP" \
+                --image "$IMAGE_TAG" \
+                --query name \
+                -o tsv)"
+
+              wait_for_job "$job_name" "$execution_name"
+            }
+
+            case "$DB_COMMAND" in
+              migrate-and-seed)
+                run_job "$AZURE_DB_MIGRATE_JOB_NAME"
+                run_job "$AZURE_DB_SEED_JOB_NAME"
+                ;;
+              migrate)
+                run_job "$AZURE_DB_MIGRATE_JOB_NAME"
+                ;;
+              seed)
+                run_job "$AZURE_DB_SEED_JOB_NAME"
+                ;;
+              *)
+                echo "Unknown command: $DB_COMMAND"
+                exit 1
+                ;;
+            esac

--- a/.github/workflows/deploy-planner-ai-worker.yml
+++ b/.github/workflows/deploy-planner-ai-worker.yml
@@ -1,54 +1,76 @@
-﻿name: Deploy Planner.AI to DigitalOcean
+name: Deploy Planner.AI to Azure Container Apps
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
+    paths:
+      - 'src/Planner.AI/**'
+      - '.github/workflows/deploy-planner-ai-worker.yml'
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AZURE_CONTAINER_REGISTRY: ${{ vars.AZURE_CONTAINER_REGISTRY }}
+  AZURE_CONTAINER_APP_NAME: ${{ vars.AZURE_AI_WORKER_CONTAINER_APP_NAME }}
+  AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+  IMAGE_NAME: planner-ai-worker
 
 jobs:
-  deploy:
+  build-and-deploy:
     runs-on: ubuntu-latest
+    environment: dev
+
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Deploy to Droplet
-        uses: appleboy/ssh-action@v1.0.3
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
         with:
-          host: ${{ secrets.SSH_HOST }}
-          username: root
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          script: |
-            # 1. Prepare the workspace
-            mkdir -p ~/planner-ai
-            cd ~/planner-ai
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-            # 2. Initialize or update a Sparse Checkout
-            if [ ! -d ".git" ]; then
-                git init
-                git remote add origin https://github.com/stephen-wu-chaohui/Planner
-                git config core.sparseCheckout true
-                echo "src/Planner.AI" >> .git/info/sparse-checkout
-                echo "src/Planner.AI/*" >> .git/info/sparse-checkout
-            fi
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-            git fetch origin main
-            git reset --hard origin/main
+      - name: Login to ACR (OIDC)
+        run: |
+          az acr login --name $(echo "${AZURE_CONTAINER_REGISTRY}" | cut -d'.' -f1)
 
-            # 3. Navigate to the code
-            cd src/Planner.AI
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: src/Planner.AI
+          file: src/Planner.AI/Dockerfile
+          push: true
+          tags: |
+            ${{ env.AZURE_CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.AZURE_CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
-            # 4. Build the image
-            # This will now find the Dockerfile in the current directory
-            docker build -t planner-ai-worker .
+      - name: Install Azure Container Apps extension
+        uses: azure/CLI@v2
+        with:
+          inlineScript: |
+            az extension add --name containerapp --upgrade
 
-            # 5. Cleanup existing container
-            docker stop planner-ai-worker || true
-            docker rm planner-ai-worker || true
+      - name: Deploy to Azure Container Apps
+        uses: azure/CLI@v2
+        with:
+          inlineScript: |
+            set -eo pipefail
 
-            # 6. Run the worker
-            # IMPORTANT: Ensure your .env file is located at ~/planner-ai/.env
-            docker run -d \
-                --name planner-ai-worker \
-                --restart always \
-                --env-file ../../.env \
-                planner-ai-worker
+            IMAGE_TAG="${AZURE_CONTAINER_REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}"
+
+            az containerapp show \
+              --name "${AZURE_CONTAINER_APP_NAME}" \
+              --resource-group "${AZURE_RESOURCE_GROUP}" \
+              >/dev/null
+
+            az containerapp update \
+              --name "${AZURE_CONTAINER_APP_NAME}" \
+              --resource-group "${AZURE_RESOURCE_GROUP}" \
+              --image "${IMAGE_TAG}"

--- a/.github/workflows/deploy-planner-api-aca.yml
+++ b/.github/workflows/deploy-planner-api-aca.yml
@@ -1,4 +1,4 @@
-﻿name: Deploy Planner.API to Azure Container Apps (dev)
+name: Deploy Planner.API to Azure Container Apps (dev)
 
 on:
   workflow_dispatch:
@@ -21,46 +21,20 @@ permissions:
   contents: read
 
 env:
-  AZURE_CONTAINER_REGISTRY: ${{ secrets.AZURE_CONTAINER_REGISTRY }}   # e.g. myregistry.azurecr.io
-  AZURE_CONTAINER_APP_NAME: ${{ secrets.AZURE_API_CONTAINER_APP_NAME }} # e.g. planner-api
-  AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
-  AZURE_CONTAINERAPPS_ENVIRONMENT: ${{ secrets.AZURE_CONTAINERAPPS_ENVIRONMENT }}
-  AZUREAD_CLIENTID: ${{ secrets.AZUREAD_CLIENTID_API }}
-
-  FIRESTORE_PROJECTID: ${{ secrets.FIRESTORE_PROJECTID }}
-  FIREBASE_CONFIG_JSON: ${{ secrets.FIREBASE_CONFIG_JSON }}
-  GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-  GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-  GEMINI_MODEL: ${{ secrets.GEMINI_MODEL }}
+  AZURE_CONTAINER_REGISTRY: ${{ vars.AZURE_CONTAINER_REGISTRY }}
+  AZURE_CONTAINER_APP_NAME: ${{ vars.AZURE_API_CONTAINER_APP_NAME }}
+  AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
   IMAGE_NAME: planner-api
-
-  # Required configuration (match Program.cs)
-  PLANNERDB_CONNECTION: ${{ secrets.PLANNERDB_CONNECTION }}
-  REDIS_CONNECTION: ${{ secrets.REDIS_CONNECTION }}
-  RABBITMQ_HOST: ${{ secrets.RABBITMQ_HOST }}     # should be 'rabbitmq' (the container app name)
-  RABBITMQ_PORT: ${{ secrets.RABBITMQ_PORT }}     # usually 5672
-  RABBITMQ_USER: ${{ secrets.RABBITMQ_USER }}     # NOT guest in Azure
-  RABBITMQ_PASS: ${{ secrets.RABBITMQ_PASS }}
-
-  SIGNALR_CLIENT: ${{ secrets.SIGNALR_CLIENT }}   # whatever your app expects
-  SIGNALR_ROUTE: ${{ secrets.SIGNALR_ROUTE }}     # e.g. /hubs/optimization
-  JWT_ISSUER: ${{ secrets.JWT_ISSUER }}
-  JWT_AUDIENCE: ${{ secrets.JWT_AUDIENCE }}
-  JWT_SIGNING_KEY: ${{ secrets.JWT_SIGNING_KEY }}
-  JWT_SECRET: ${{ secrets.JWT_SECRET }}
-  EXPIRATION_IN_MINUTES: 60
-
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment: dev
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # ---------------------------
-      # Azure login (OIDC)
-      # ---------------------------
       - name: Azure login (OIDC)
         uses: azure/login@v2
         with:
@@ -71,16 +45,10 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # ---------------------------
-      # Login to ACR using OIDC (CHANGED)
-      # ---------------------------
       - name: Login to ACR (OIDC)
         run: |
           az acr login --name $(echo "${AZURE_CONTAINER_REGISTRY}" | cut -d'.' -f1)
 
-      # ---------------------------
-      # Build and push image
-      # ---------------------------
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
@@ -97,9 +65,6 @@ jobs:
           inlineScript: |
             az extension add --name containerapp --upgrade
 
-      # ---------------------------
-      # Deploy to Azure Container Apps
-      # ---------------------------
       - name: Deploy to Azure Container Apps
         uses: azure/CLI@v2
         with:
@@ -108,62 +73,12 @@ jobs:
 
             IMAGE_TAG="${AZURE_CONTAINER_REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}"
 
-            # Create if missing (optional convenience)
-            # az containerapp show \
-            #   --name "${AZURE_CONTAINER_APP_NAME}" \
-            #   --resource-group "${AZURE_RESOURCE_GROUP}" \
-            #   >/dev/null 2>&1 || \
-            # az containerapp create \
-            #   --name planner-api \
-            #   --resource-group "$AZURE_RESOURCE_GROUP" \
-            #   --environment "$AZURE_CONTAINERAPPS_ENVIRONMENT" \
-            #   --image "$IMAGE_TAG" \
-            #   --ingress external \
-            #   --target-port 8080 \
-            #   --transport auto \
-            #   --registry-server "$AZURE_CONTAINER_REGISTRY" \
-            #   --env-vars \
-            #     ASPNETCORE_URLS=http://+:8080 \
-            #     ConnectionStrings__PlannerDb="$PLANNERDB_CONNECTION" \
-            #     RabbitMq__Host="$RABBITMQ_HOST" \
-            #     RabbitMq__Port="$RABBITMQ_PORT" \
-            #     RabbitMq__User="$RABBITMQ_USER" \
-            #     RabbitMq__Pass="$RABBITMQ_PASS" \
-            #     SignalR__Client="$SIGNALR_CLIENT" \
-            #     SignalR__Route="$SIGNALR_ROUTE"
+            az containerapp show \
+              --name "${AZURE_CONTAINER_APP_NAME}" \
+              --resource-group "${AZURE_RESOURCE_GROUP}" \
+              >/dev/null
 
-            # Update image + env vars
             az containerapp update \
               --name "${AZURE_CONTAINER_APP_NAME}" \
               --resource-group "${AZURE_RESOURCE_GROUP}" \
-              --image "${IMAGE_TAG}" \
-              --set-env-vars \
-                ASPNETCORE_ENVIRONMENT=Production  \
-                ASPNETCORE_URLS="http://+:8080" \
-                ConnectionStrings__PlannerDb="${PLANNERDB_CONNECTION}" \
-                ConnectionStrings__Redis="${REDIS_CONNECTION}" \
-                RabbitMq__Host="${RABBITMQ_HOST}" \
-                RabbitMq__Port="${RABBITMQ_PORT}" \
-                RabbitMq__User="${RABBITMQ_USER}" \
-                RabbitMq__Pass="${RABBITMQ_PASS}" \
-                SignalR__Client="${SIGNALR_CLIENT}" \
-                SignalR__Route="${SIGNALR_ROUTE}"   \
-                JwtOptions__Issuer="${JWT_ISSUER}"    \
-                JwtOptions__Audience="${JWT_AUDIENCE}"    \
-                JwtOptions__SigningKey="${JWT_SIGNING_KEY}"   \
-                JwtOptions__Secret="${JWT_SECRET}"            \
-                JwtOptions__ExpirationInMinutes="${EXPIRATION_IN_MINUTES}"  \
-                Firestore__ProjectId="${FIRESTORE_PROJECTID}"      \
-                AzureAd__Instance="https://login.microsoftonline.com/"        \
-                AzureAd__Domain="plannerdemo.com"               \
-                AzureAd__TenantId="common"         \
-                AzureAd__ClientId="${AZUREAD_CLIENTID}"         \
-                FIREBASE_CONFIG_JSON="${FIREBASE_CONFIG_JSON}"     \
-                GOOGLE_API_KEY="${GOOGLE_API_KEY}"        \
-                GEMINI_API_KEY="${GEMINI_API_KEY}"          \
-                GEMINI_MODEL="${GEMINI_MODEL}"
-
-
-
-
-
+              --image "${IMAGE_TAG}"

--- a/.github/workflows/deploy-planner-optimization-worker-aca.yml
+++ b/.github/workflows/deploy-planner-optimization-worker-aca.yml
@@ -1,4 +1,4 @@
-﻿name: Deploy planner.optimization.worker to Azure Container Apps
+name: Deploy planner.optimization.worker to Azure Container Apps
 
 on:
   workflow_dispatch:
@@ -20,29 +20,20 @@ permissions:
   contents: read
 
 env:
-  AZURE_CONTAINER_REGISTRY: ${{ secrets.AZURE_CONTAINER_REGISTRY }} # e.g. myregistry.azurecr.io
-  AZURE_CONTAINER_APP_NAME: ${{ secrets.AZURE_CONTAINER_APP_NAME }} # e.g. planner-optimization-worker
-  AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
-  AZURE_CONTAINERAPPS_ENVIRONMENT: ${{ secrets.AZURE_CONTAINERAPPS_ENVIRONMENT }} # name of the Container Apps Environment
+  AZURE_CONTAINER_REGISTRY: ${{ vars.AZURE_CONTAINER_REGISTRY }}
+  AZURE_CONTAINER_APP_NAME: ${{ vars.AZURE_OPTIMIZATION_CONTAINER_APP_NAME }}
+  AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
   IMAGE_NAME: planner-optimization-worker
-
-  # RabbitMQ (connection settings injected as environment variables)
-  RABBITMQ_HOST: ${{ secrets.RABBITMQ_HOST }}
-  RABBITMQ_PORT: ${{ secrets.RABBITMQ_PORT }}
-  RABBITMQ_USER: ${{ secrets.RABBITMQ_USER }}
-  RABBITMQ_PASS: ${{ secrets.RABBITMQ_PASS }}
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment: dev
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # ---------------------------
-      # Azure login (OIDC)
-      # ---------------------------
       - name: Azure login (OIDC)
         uses: azure/login@v2
         with:
@@ -53,16 +44,10 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # ---------------------------
-      # Login to ACR using OIDC (CHANGED)
-      # ---------------------------
       - name: Login to ACR (OIDC)
         run: |
           az acr login --name $(echo "${AZURE_CONTAINER_REGISTRY}" | cut -d'.' -f1)
 
-      # ---------------------------
-      # Build and push image
-      # ---------------------------
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
@@ -79,9 +64,6 @@ jobs:
           inlineScript: |
             az extension add --name containerapp --upgrade
 
-      # ---------------------------
-      # Deploy to Azure Container Apps
-      # ---------------------------
       - name: Deploy to Azure Container Apps
         uses: azure/CLI@v2
         with:
@@ -90,18 +72,12 @@ jobs:
 
             IMAGE_TAG="${AZURE_CONTAINER_REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}"
 
+            az containerapp show \
+              --name "${AZURE_CONTAINER_APP_NAME}" \
+              --resource-group "${AZURE_RESOURCE_GROUP}" \
+              >/dev/null
+
             az containerapp update \
-            --name "${AZURE_CONTAINER_APP_NAME}" \
-            --resource-group "${AZURE_RESOURCE_GROUP}" \
-            --image "${IMAGE_TAG}" \
-            --set-env-vars \
-                RabbitMq__Host="${RABBITMQ_HOST}" \
-                RabbitMq__Port="${RABBITMQ_PORT}" \
-                RabbitMq__User="${RABBITMQ_USER}" \
-                RabbitMq__Pass="${RABBITMQ_PASS}"
-
-
-            # Ensure secrets are stored in Container Apps (optional but recommended):
-            # If you prefer secrets in ACA, replace the env-vars above with:
-            #   --secrets rabbitmq-pass="${RABBITMQ_PASS}" \
-            #   --env-vars RabbitMq__Pass=secretref:rabbitmq-pass ...
+              --name "${AZURE_CONTAINER_APP_NAME}" \
+              --resource-group "${AZURE_RESOURCE_GROUP}" \
+              --image "${IMAGE_TAG}"

--- a/.github/workflows/main_planner-blazor-dev.yml
+++ b/.github/workflows/main_planner-blazor-dev.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment: dev
 
     steps:
       - name: Checkout
@@ -41,7 +42,7 @@ jobs:
         run: |
           dotnet restore src/Planner.BlazorApp/Planner.BlazorApp.csproj
 
-      - name: Build & publish Planner.BlazorApp
+      - name: Build and publish Planner.BlazorApp
         run: |
           dotnet publish src/Planner.BlazorApp/Planner.BlazorApp.csproj \
             -c Release \
@@ -50,6 +51,5 @@ jobs:
       - name: Deploy Planner.BlazorApp to Azure App Service
         uses: azure/webapps-deploy@v3
         with:
-          app-name: planner-blazor-dev
+          app-name: ${{ vars.AZURE_BLAZOR_APP_NAME }}
           package: ${{ github.workspace }}/publish
-

--- a/.gitignore
+++ b/.gitignore
@@ -504,6 +504,10 @@ $RECYCLE.BIN/
 /src/Planner.BlazorApp/wwwroot/data
 /aip
 *.ps1
+!/scripts/azure/*.ps1
 *.txt
 /tools/Planner.Tools.DbMigrator/Properties/launchSettings.json
 /src/Credentials
+AI prompts/
+infra/main.json
+infra/.last-deployment-outputs.json

--- a/docs/AZURE_NEW_SUBSCRIPTION_DEPLOYMENT.md
+++ b/docs/AZURE_NEW_SUBSCRIPTION_DEPLOYMENT.md
@@ -1,0 +1,101 @@
+# Planner New Subscription Deployment
+
+This runbook rebuilds the dev deployment in a new Azure subscription.
+
+## Prerequisites
+
+- Azure CLI logged in to the new subscription.
+- Permissions to create resource groups, role assignments, app registrations, and Key Vault secrets.
+- `gh` authenticated to `stephen-wu-chaohui/Planner`.
+- Access to the existing `plannerdemo.com` DNS provider.
+- Fresh Google/Firebase/Gemini/Maps credentials from the existing Google/Firebase project.
+
+## 1. Deploy Azure Infrastructure
+
+Preview:
+
+```powershell
+./scripts/azure/deploy-infra.ps1 -WhatIf
+```
+
+Deploy:
+
+```powershell
+./scripts/azure/deploy-infra.ps1
+```
+
+This creates `rg-planner-dev-aue`, ACR, Key Vault, Log Analytics/App Insights, Container Apps, RabbitMQ with Azure Files storage, Azure SQL, App Service, and DbMigrator jobs.
+
+## 2. Bootstrap Entra ID
+
+```powershell
+./scripts/azure/bootstrap-entra.ps1 -DemoPassword "<temporary-demo-user-password>"
+```
+
+This creates or updates:
+
+- `planner-dev-api` with `API.Access`.
+- `planner-dev-blazor` with `https://planner.plannerdemo.com/signin-oidc`.
+- `planner-dev-github-deploy` with GitHub OIDC subject `repo:stephen-wu-chaohui/Planner:environment:dev`.
+- Demo admin users for the seeded tenants.
+
+It stores app ids, the Blazor client secret, and the API scope in Key Vault.
+
+## 3. Store Rotated Runtime Secrets
+
+```powershell
+./scripts/azure/set-runtime-secrets.ps1 `
+  -FirestoreProjectId "<project-id>" `
+  -FirebaseConfigJsonPath "<service-account.json>" `
+  -GoogleApiKey "<google-api-key>" `
+  -GoogleMapsApiKey "<maps-key>" `
+  -GoogleMapsMapId "<map-id>" `
+  -GeminiApiKey "<gemini-key>"
+```
+
+## 4. Configure GitHub
+
+```powershell
+./scripts/azure/configure-github.ps1
+```
+
+GitHub environment `dev` receives only the Azure OIDC secrets. Resource names are stored as environment variables.
+
+## 5. Configure DNS And Certificates
+
+Print required DNS records:
+
+```powershell
+./scripts/azure/configure-custom-domains.ps1
+```
+
+Create these records with the current DNS provider:
+
+- `planner` CNAME to the App Service default hostname.
+- `asuid.planner` TXT to the App Service verification id.
+- `api` CNAME to the Container Apps hostname.
+- `asuid.api` TXT to the Container Apps verification id.
+
+After DNS propagates:
+
+```powershell
+./scripts/azure/configure-custom-domains.ps1 -Bind
+```
+
+## 6. Deploy Images And Database
+
+Run the GitHub workflows in this order:
+
+1. `Deploy Planner.API to Azure Container Apps (dev)`
+2. `Deploy planner.optimization.worker to Azure Container Apps`
+3. `Deploy Planner.AI to Azure Container Apps`
+4. `Deploy Planner.BlazorApp (dev)`
+5. `Database Migrate & Seed (dev)` with `migrate-and-seed`
+
+## 7. Smoke Test
+
+- `https://api.plannerdemo.com/health` returns healthy.
+- `https://api.plannerdemo.com/graphql` loads.
+- `https://planner.plannerdemo.com` redirects through Entra login.
+- Sign in as `auckland.admin@plannerdemo.com`.
+- Submit an optimization request and verify API -> RabbitMQ -> worker -> Firestore -> AI insight -> Blazor display.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,38 @@
+# Planner Azure Dev Infrastructure
+
+This folder contains the Bicep entrypoint for rebuilding Planner in a new Azure subscription.
+
+## Deploy
+
+```powershell
+./scripts/azure/deploy-infra.ps1
+```
+
+Use `-WhatIf` first when checking a subscription:
+
+```powershell
+./scripts/azure/deploy-infra.ps1 -WhatIf
+```
+
+The script creates or updates `rg-planner-dev-aue` in `australiaeast`, generates SQL/RabbitMQ passwords for the first deployment, and reuses those values from Key Vault on later runs.
+
+## Outputs
+
+After a successful deployment, the script writes `infra/.last-deployment-outputs.json` locally. That file is intentionally ignored because it contains environment-specific resource names.
+
+## Follow-Up Scripts
+
+Run these after infrastructure deployment:
+
+```powershell
+./scripts/azure/bootstrap-entra.ps1
+./scripts/azure/set-runtime-secrets.ps1 -FirestoreProjectId "<project-id>" -FirebaseConfigJsonPath "<service-account.json>" -GoogleApiKey "<google-api-key>" -GoogleMapsApiKey "<maps-key>" -GoogleMapsMapId "<map-id>" -GeminiApiKey "<gemini-key>"
+./scripts/azure/configure-github.ps1
+./scripts/azure/configure-custom-domains.ps1
+```
+
+After DNS records are visible, bind the custom domains:
+
+```powershell
+./scripts/azure/configure-custom-domains.ps1 -Bind
+```

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,89 @@
+targetScope = 'subscription'
+
+@description('Azure region for all Planner dev resources.')
+param location string = 'australiaeast'
+
+@description('Resource group name for the Planner dev deployment.')
+param resourceGroupName string = 'rg-planner-dev-aue'
+
+@description('Name prefix used for Azure resources.')
+param namePrefix string = 'planner-dev'
+
+@description('Short suffix for globally unique Azure resource names. Defaults to a deterministic value for the subscription.')
+param uniqueSuffix string = toLower(take(uniqueString(subscription().subscriptionId, namePrefix, location), 6))
+
+@description('SQL administrator login name.')
+param sqlAdminLogin string = 'planneradmin'
+
+@secure()
+@description('SQL administrator password. The deployment script generates or reuses this from Key Vault.')
+param sqlAdminPassword string
+
+@secure()
+@description('RabbitMQ password. The deployment script generates or reuses this from Key Vault.')
+param rabbitMqPassword string
+
+@description('RabbitMQ username.')
+param rabbitMqUser string = 'planner'
+
+@description('Custom hostname for the Blazor app.')
+param plannerHostName string = 'planner.plannerdemo.com'
+
+@description('Custom hostname for the API.')
+param apiHostName string = 'api.plannerdemo.com'
+
+@description('Entra ID domain used by Planner app registrations.')
+param entraDomain string = 'plannerdemo.com'
+
+@description('Entra ID tenant id. Defaults to the tenant used for the deployment.')
+param entraTenantId string = tenant().tenantId
+
+@description('Container image for the Planner API Container App.')
+param apiImage string = 'mcr.microsoft.com/dotnet/samples:aspnetapp'
+
+@description('Container image for the optimization worker Container App.')
+param optimizationWorkerImage string = 'mcr.microsoft.com/dotnet/samples:aspnetapp'
+
+@description('Container image for the AI worker Container App.')
+param aiWorkerImage string = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+
+@description('Container image for the DbMigrator Container Apps jobs.')
+param dbMigratorImage string = 'mcr.microsoft.com/dotnet/aspnet:10.0'
+
+resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: resourceGroupName
+  location: location
+  tags: {
+    app: 'Planner'
+    environment: 'dev'
+  }
+}
+
+module core 'modules/core.bicep' = {
+  name: 'planner-dev-core'
+  scope: rg
+  params: {
+    location: location
+    namePrefix: namePrefix
+    uniqueSuffix: uniqueSuffix
+    sqlAdminLogin: sqlAdminLogin
+    sqlAdminPassword: sqlAdminPassword
+    rabbitMqUser: rabbitMqUser
+    rabbitMqPassword: rabbitMqPassword
+    plannerHostName: plannerHostName
+    apiHostName: apiHostName
+    entraDomain: entraDomain
+    entraTenantId: entraTenantId
+    apiImage: apiImage
+    optimizationWorkerImage: optimizationWorkerImage
+    aiWorkerImage: aiWorkerImage
+    dbMigratorImage: dbMigratorImage
+  }
+}
+
+output resourceGroupName string = rg.name
+output azureRegion string = location
+output names object = core.outputs.names
+output githubVariables object = core.outputs.githubVariables
+output dnsRecords object = core.outputs.dnsRecords
+output keyVaultName string = core.outputs.keyVaultName

--- a/infra/modules/core.bicep
+++ b/infra/modules/core.bicep
@@ -1,0 +1,1135 @@
+param location string
+param namePrefix string
+param uniqueSuffix string
+param sqlAdminLogin string
+@secure()
+param sqlAdminPassword string
+param rabbitMqUser string
+@secure()
+param rabbitMqPassword string
+param plannerHostName string
+param apiHostName string
+param entraDomain string
+param entraTenantId string
+param apiImage string = 'mcr.microsoft.com/dotnet/samples:aspnetapp'
+param optimizationWorkerImage string = 'mcr.microsoft.com/dotnet/samples:aspnetapp'
+param aiWorkerImage string = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+param dbMigratorImage string = 'mcr.microsoft.com/dotnet/aspnet:10.0'
+
+var compactPrefix = toLower(replace(namePrefix, '-', ''))
+var suffix = toLower(uniqueSuffix)
+
+var acrName = toLower(take('${compactPrefix}${suffix}acr', 50))
+var appInsightsName = '${namePrefix}-${suffix}-appi'
+var containerAppsEnvironmentName = '${namePrefix}-${suffix}-cae'
+var keyVaultName = toLower(take('${namePrefix}-${suffix}-kv', 24))
+var logAnalyticsName = '${namePrefix}-${suffix}-log'
+var storageName = toLower(take('${compactPrefix}${suffix}st', 24))
+var fileShareName = 'rabbitmq'
+var appServicePlanName = '${namePrefix}-${suffix}-asp'
+var blazorAppName = '${namePrefix}-${suffix}-web'
+var sqlServerName = toLower('${namePrefix}-${suffix}-sql')
+var sqlDatabaseName = 'PlannerDB-dev'
+
+var apiContainerAppName = '${namePrefix}-api'
+var optimizationWorkerContainerAppName = '${namePrefix}-optimization-worker'
+var aiWorkerContainerAppName = '${namePrefix}-ai-worker'
+var rabbitMqContainerAppName = 'rabbitmq'
+var migrateJobName = '${namePrefix}-db-migrate'
+var seedJobName = '${namePrefix}-db-seed'
+
+var apiIdentityName = '${namePrefix}-api-id'
+var optimizationWorkerIdentityName = '${namePrefix}-optimization-worker-id'
+var aiWorkerIdentityName = '${namePrefix}-ai-worker-id'
+var migratorIdentityName = '${namePrefix}-db-migrator-id'
+
+var acrPullRoleId = '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+var keyVaultSecretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6'
+
+var plannerDbConnectionString = 'Server=tcp:${sqlServer.properties.fullyQualifiedDomainName},1433;Initial Catalog=${sqlDatabaseName};Persist Security Info=False;User ID=${sqlAdminLogin};Password=${sqlAdminPassword};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;'
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: logAnalyticsName
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: appInsightsName
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: logAnalytics.id
+  }
+}
+
+resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+  name: acrName
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  properties: {
+    adminUserEnabled: false
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: keyVaultName
+  location: location
+  properties: {
+    tenantId: entraTenantId
+    enableRbacAuthorization: true
+    enableSoftDelete: true
+    softDeleteRetentionInDays: 7
+    publicNetworkAccess: 'Enabled'
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+  }
+}
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    allowBlobPublicAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+resource fileService 'Microsoft.Storage/storageAccounts/fileServices@2023-05-01' = {
+  parent: storage
+  name: 'default'
+}
+
+resource rabbitMqShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-05-01' = {
+  parent: fileService
+  name: fileShareName
+  properties: {
+    shareQuota: 5
+  }
+}
+
+resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
+  name: sqlServerName
+  location: location
+  properties: {
+    administratorLogin: sqlAdminLogin
+    administratorLoginPassword: sqlAdminPassword
+    publicNetworkAccess: 'Enabled'
+    minimalTlsVersion: '1.2'
+  }
+}
+
+resource sqlAllowAzure 'Microsoft.Sql/servers/firewallRules@2023-08-01-preview' = {
+  parent: sqlServer
+  name: 'AllowAllWindowsAzureIps'
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '0.0.0.0'
+  }
+}
+
+resource sqlDatabase 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+  parent: sqlServer
+  name: sqlDatabaseName
+  location: location
+  sku: {
+    name: 'Basic'
+    tier: 'Basic'
+    capacity: 5
+  }
+  properties: {
+    maxSizeBytes: 2147483648
+  }
+}
+
+resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: appServicePlanName
+  location: location
+  sku: {
+    name: 'B1'
+    tier: 'Basic'
+    size: 'B1'
+    capacity: 1
+  }
+  kind: 'linux'
+  properties: {
+    reserved: true
+  }
+}
+
+resource apiIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: apiIdentityName
+  location: location
+}
+
+resource optimizationWorkerIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: optimizationWorkerIdentityName
+  location: location
+}
+
+resource aiWorkerIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: aiWorkerIdentityName
+  location: location
+}
+
+resource migratorIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: migratorIdentityName
+  location: location
+}
+
+resource apiAcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, apiIdentity.id, acrPullRoleId)
+  scope: acr
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', acrPullRoleId)
+    principalId: apiIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource optimizationWorkerAcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, optimizationWorkerIdentity.id, acrPullRoleId)
+  scope: acr
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', acrPullRoleId)
+    principalId: optimizationWorkerIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource aiWorkerAcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, aiWorkerIdentity.id, acrPullRoleId)
+  scope: acr
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', acrPullRoleId)
+    principalId: aiWorkerIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource migratorAcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, migratorIdentity.id, acrPullRoleId)
+  scope: acr
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', acrPullRoleId)
+    principalId: migratorIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource apiKeyVaultSecretsUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, apiIdentity.id, keyVaultSecretsUserRoleId)
+  scope: keyVault
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: apiIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource optimizationWorkerKeyVaultSecretsUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, optimizationWorkerIdentity.id, keyVaultSecretsUserRoleId)
+  scope: keyVault
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: optimizationWorkerIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource aiWorkerKeyVaultSecretsUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, aiWorkerIdentity.id, keyVaultSecretsUserRoleId)
+  scope: keyVault
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: aiWorkerIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource migratorKeyVaultSecretsUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, migratorIdentity.id, keyVaultSecretsUserRoleId)
+  scope: keyVault
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: migratorIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2024-03-01' = {
+  name: containerAppsEnvironmentName
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalytics.properties.customerId
+        sharedKey: logAnalytics.listKeys().primarySharedKey
+      }
+    }
+  }
+}
+
+resource containerAppsStorage 'Microsoft.App/managedEnvironments/storages@2024-03-01' = {
+  parent: containerAppsEnvironment
+  name: 'rabbitmq-data'
+  properties: {
+    azureFile: {
+      accountName: storage.name
+      accountKey: storage.listKeys().keys[0].value
+      shareName: rabbitMqShare.name
+      accessMode: 'ReadWrite'
+    }
+  }
+}
+
+resource plannerDbConnectionSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'plannerdb-connection'
+  properties: {
+    value: plannerDbConnectionString
+  }
+}
+
+resource sqlAdminPasswordSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'sql-admin-password'
+  properties: {
+    value: sqlAdminPassword
+  }
+}
+
+resource rabbitMqUserSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'rabbitmq-user'
+  properties: {
+    value: rabbitMqUser
+  }
+}
+
+resource rabbitMqPasswordSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'rabbitmq-pass'
+  properties: {
+    value: rabbitMqPassword
+  }
+}
+
+resource firestoreProjectIdSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'firestore-project-id'
+  properties: {
+    value: 'pending-bootstrap'
+  }
+}
+
+resource firebaseConfigJsonSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'firebase-config-json'
+  properties: {
+    value: 'pending-bootstrap'
+  }
+}
+
+resource googleApiKeySecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'google-api-key'
+  properties: {
+    value: 'pending-bootstrap'
+  }
+}
+
+resource googleMapsApiKeySecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'google-maps-api-key'
+  properties: {
+    value: 'pending-bootstrap'
+  }
+}
+
+resource googleMapsMapIdSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'google-maps-map-id'
+  properties: {
+    value: 'pending-bootstrap'
+  }
+}
+
+resource geminiApiKeySecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'gemini-api-key'
+  properties: {
+    value: 'pending-bootstrap'
+  }
+}
+
+resource geminiModelSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'gemini-model'
+  properties: {
+    value: 'gemini-2.5-flash'
+  }
+}
+
+resource azureAdTenantIdSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'azuread-tenant-id'
+  properties: {
+    value: entraTenantId
+  }
+}
+
+resource azureAdDomainSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'azuread-domain'
+  properties: {
+    value: entraDomain
+  }
+}
+
+resource azureAdApiClientIdSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'azuread-api-client-id'
+  properties: {
+    value: 'pending-bootstrap'
+  }
+}
+
+resource azureAdBlazorClientIdSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'azuread-blazor-client-id'
+  properties: {
+    value: 'pending-bootstrap'
+  }
+}
+
+resource azureAdBlazorClientSecretSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'azuread-blazor-client-secret'
+  properties: {
+    value: 'pending-bootstrap'
+  }
+}
+
+resource apiScopeSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'api-scope'
+  properties: {
+    value: 'api://pending-bootstrap/API.Access'
+  }
+}
+
+resource githubDeployClientIdSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'github-deploy-client-id'
+  properties: {
+    value: 'pending-bootstrap'
+  }
+}
+
+var keyVaultSecretDependencies = [
+  plannerDbConnectionSecret
+  sqlAdminPasswordSecret
+  rabbitMqUserSecret
+  rabbitMqPasswordSecret
+  firestoreProjectIdSecret
+  firebaseConfigJsonSecret
+  googleApiKeySecret
+  googleMapsApiKeySecret
+  googleMapsMapIdSecret
+  geminiApiKeySecret
+  geminiModelSecret
+  azureAdTenantIdSecret
+  azureAdDomainSecret
+  azureAdApiClientIdSecret
+  azureAdBlazorClientIdSecret
+  azureAdBlazorClientSecretSecret
+  apiScopeSecret
+  githubDeployClientIdSecret
+]
+
+resource blazorApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: blazorAppName
+  location: location
+  kind: 'app,linux'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: appServicePlan.id
+    httpsOnly: true
+    clientAffinityEnabled: true
+    siteConfig: {
+      linuxFxVersion: 'DOTNETCORE|10.0'
+      alwaysOn: true
+      webSocketsEnabled: true
+      appSettings: [
+        {
+          name: 'ASPNETCORE_ENVIRONMENT'
+          value: 'Production'
+        }
+        {
+          name: 'Api__BaseUrl'
+          value: 'https://${apiHostName}'
+        }
+        {
+          name: 'Api__Scope'
+          value: '@Microsoft.KeyVault(SecretUri=${keyVault.properties.vaultUri}secrets/api-scope)'
+        }
+        {
+          name: 'AzureAd__Instance'
+          value: 'https://login.microsoftonline.com/'
+        }
+        {
+          name: 'AzureAd__Domain'
+          value: '@Microsoft.KeyVault(SecretUri=${keyVault.properties.vaultUri}secrets/azuread-domain)'
+        }
+        {
+          name: 'AzureAd__TenantId'
+          value: '@Microsoft.KeyVault(SecretUri=${keyVault.properties.vaultUri}secrets/azuread-tenant-id)'
+        }
+        {
+          name: 'AzureAd__ClientId'
+          value: '@Microsoft.KeyVault(SecretUri=${keyVault.properties.vaultUri}secrets/azuread-blazor-client-id)'
+        }
+        {
+          name: 'AzureAd__ClientSecret'
+          value: '@Microsoft.KeyVault(SecretUri=${keyVault.properties.vaultUri}secrets/azuread-blazor-client-secret)'
+        }
+        {
+          name: 'AzureAd__Scopes'
+          value: '@Microsoft.KeyVault(SecretUri=${keyVault.properties.vaultUri}secrets/api-scope)'
+        }
+        {
+          name: 'AzureAd__CallbackPath'
+          value: '/signin-oidc'
+        }
+        {
+          name: 'GoogleMaps__ApiKey'
+          value: '@Microsoft.KeyVault(SecretUri=${keyVault.properties.vaultUri}secrets/google-maps-api-key)'
+        }
+        {
+          name: 'GoogleMaps__MapId'
+          value: '@Microsoft.KeyVault(SecretUri=${keyVault.properties.vaultUri}secrets/google-maps-map-id)'
+        }
+        {
+          name: 'Firestore__ProjectId'
+          value: '@Microsoft.KeyVault(SecretUri=${keyVault.properties.vaultUri}secrets/firestore-project-id)'
+        }
+        {
+          name: 'FIREBASE_CONFIG_JSON'
+          value: '@Microsoft.KeyVault(SecretUri=${keyVault.properties.vaultUri}secrets/firebase-config-json)'
+        }
+        {
+          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+          value: appInsights.properties.ConnectionString
+        }
+      ]
+    }
+  }
+  dependsOn: keyVaultSecretDependencies
+}
+
+resource blazorKeyVaultSecretsUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, blazorApp.id, keyVaultSecretsUserRoleId)
+  scope: keyVault
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: blazorApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource rabbitMqApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: rabbitMqContainerAppName
+  location: location
+  properties: {
+    managedEnvironmentId: containerAppsEnvironment.id
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: false
+        targetPort: 5672
+        transport: 'tcp'
+        exposedPort: 5672
+      }
+      secrets: [
+        {
+          name: 'rabbitmq-user'
+          value: rabbitMqUser
+        }
+        {
+          name: 'rabbitmq-pass'
+          value: rabbitMqPassword
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'rabbitmq'
+          image: 'rabbitmq:3-management'
+          env: [
+            {
+              name: 'RABBITMQ_DEFAULT_USER'
+              secretRef: 'rabbitmq-user'
+            }
+            {
+              name: 'RABBITMQ_DEFAULT_PASS'
+              secretRef: 'rabbitmq-pass'
+            }
+          ]
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          volumeMounts: [
+            {
+              volumeName: 'rabbitmq-data'
+              mountPath: '/var/lib/rabbitmq/mnesia'
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 1
+      }
+      volumes: [
+        {
+          name: 'rabbitmq-data'
+          storageType: 'AzureFile'
+          storageName: containerAppsStorage.name
+        }
+      ]
+    }
+  }
+  dependsOn: [
+    containerAppsStorage
+  ]
+}
+
+resource apiApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: apiContainerAppName
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${apiIdentity.id}': {}
+    }
+  }
+  properties: {
+    managedEnvironmentId: containerAppsEnvironment.id
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: true
+        targetPort: 8080
+        transport: 'auto'
+        allowInsecure: false
+      }
+      registries: [
+        {
+          server: acr.properties.loginServer
+          identity: apiIdentity.id
+        }
+      ]
+      secrets: [
+        {
+          name: 'plannerdb-connection'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/plannerdb-connection'
+          identity: apiIdentity.id
+        }
+        {
+          name: 'rabbitmq-user'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/rabbitmq-user'
+          identity: apiIdentity.id
+        }
+        {
+          name: 'rabbitmq-pass'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/rabbitmq-pass'
+          identity: apiIdentity.id
+        }
+        {
+          name: 'firestore-project-id'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/firestore-project-id'
+          identity: apiIdentity.id
+        }
+        {
+          name: 'firebase-config-json'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/firebase-config-json'
+          identity: apiIdentity.id
+        }
+        {
+          name: 'google-api-key'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/google-api-key'
+          identity: apiIdentity.id
+        }
+        {
+          name: 'gemini-api-key'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/gemini-api-key'
+          identity: apiIdentity.id
+        }
+        {
+          name: 'gemini-model'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/gemini-model'
+          identity: apiIdentity.id
+        }
+        {
+          name: 'azuread-domain'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/azuread-domain'
+          identity: apiIdentity.id
+        }
+        {
+          name: 'azuread-tenant-id'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/azuread-tenant-id'
+          identity: apiIdentity.id
+        }
+        {
+          name: 'azuread-api-client-id'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/azuread-api-client-id'
+          identity: apiIdentity.id
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'planner-api'
+          image: apiImage
+          env: [
+            {
+              name: 'ASPNETCORE_ENVIRONMENT'
+              value: 'Production'
+            }
+            {
+              name: 'ASPNETCORE_URLS'
+              value: 'http://+:8080'
+            }
+            {
+              name: 'ConnectionStrings__PlannerDb'
+              secretRef: 'plannerdb-connection'
+            }
+            {
+              name: 'RabbitMq__Host'
+              value: rabbitMqApp.name
+            }
+            {
+              name: 'RabbitMq__Port'
+              value: '5672'
+            }
+            {
+              name: 'RabbitMq__User'
+              secretRef: 'rabbitmq-user'
+            }
+            {
+              name: 'RabbitMq__Pass'
+              secretRef: 'rabbitmq-pass'
+            }
+            {
+              name: 'Firestore__ProjectId'
+              secretRef: 'firestore-project-id'
+            }
+            {
+              name: 'FIREBASE_CONFIG_JSON'
+              secretRef: 'firebase-config-json'
+            }
+            {
+              name: 'GOOGLE_API_KEY'
+              secretRef: 'google-api-key'
+            }
+            {
+              name: 'GEMINI_API_KEY'
+              secretRef: 'gemini-api-key'
+            }
+            {
+              name: 'GEMINI_MODEL'
+              secretRef: 'gemini-model'
+            }
+            {
+              name: 'AzureAd__Instance'
+              value: 'https://login.microsoftonline.com/'
+            }
+            {
+              name: 'AzureAd__Domain'
+              secretRef: 'azuread-domain'
+            }
+            {
+              name: 'AzureAd__TenantId'
+              secretRef: 'azuread-tenant-id'
+            }
+            {
+              name: 'AzureAd__ClientId'
+              secretRef: 'azuread-api-client-id'
+            }
+            {
+              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+              value: appInsights.properties.ConnectionString
+            }
+          ]
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 3
+      }
+    }
+  }
+  dependsOn: [
+    apiAcrPull
+    apiKeyVaultSecretsUser
+    rabbitMqApp
+  ]
+}
+
+resource optimizationWorkerApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: optimizationWorkerContainerAppName
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${optimizationWorkerIdentity.id}': {}
+    }
+  }
+  properties: {
+    managedEnvironmentId: containerAppsEnvironment.id
+    configuration: {
+      activeRevisionsMode: 'Single'
+      registries: [
+        {
+          server: acr.properties.loginServer
+          identity: optimizationWorkerIdentity.id
+        }
+      ]
+      secrets: [
+        {
+          name: 'rabbitmq-user'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/rabbitmq-user'
+          identity: optimizationWorkerIdentity.id
+        }
+        {
+          name: 'rabbitmq-pass'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/rabbitmq-pass'
+          identity: optimizationWorkerIdentity.id
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'planner-optimization-worker'
+          image: optimizationWorkerImage
+          env: [
+            {
+              name: 'ASPNETCORE_ENVIRONMENT'
+              value: 'Production'
+            }
+            {
+              name: 'RabbitMq__Host'
+              value: rabbitMqApp.name
+            }
+            {
+              name: 'RabbitMq__Port'
+              value: '5672'
+            }
+            {
+              name: 'RabbitMq__User'
+              secretRef: 'rabbitmq-user'
+            }
+            {
+              name: 'RabbitMq__Pass'
+              secretRef: 'rabbitmq-pass'
+            }
+            {
+              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+              value: appInsights.properties.ConnectionString
+            }
+          ]
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 1
+      }
+    }
+  }
+  dependsOn: [
+    optimizationWorkerAcrPull
+    optimizationWorkerKeyVaultSecretsUser
+    rabbitMqApp
+  ]
+}
+
+resource aiWorkerApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: aiWorkerContainerAppName
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${aiWorkerIdentity.id}': {}
+    }
+  }
+  properties: {
+    managedEnvironmentId: containerAppsEnvironment.id
+    configuration: {
+      activeRevisionsMode: 'Single'
+      registries: [
+        {
+          server: acr.properties.loginServer
+          identity: aiWorkerIdentity.id
+        }
+      ]
+      secrets: [
+        {
+          name: 'firebase-config-json'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/firebase-config-json'
+          identity: aiWorkerIdentity.id
+        }
+        {
+          name: 'gemini-api-key'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/gemini-api-key'
+          identity: aiWorkerIdentity.id
+        }
+        {
+          name: 'gemini-model'
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/gemini-model'
+          identity: aiWorkerIdentity.id
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'planner-ai-worker'
+          image: aiWorkerImage
+          env: [
+            {
+              name: 'PYTHONUNBUFFERED'
+              value: '1'
+            }
+            {
+              name: 'FIREBASE_CONFIG_JSON'
+              secretRef: 'firebase-config-json'
+            }
+            {
+              name: 'GEMINI_API_KEY'
+              secretRef: 'gemini-api-key'
+            }
+            {
+              name: 'GEMINI_MODEL'
+              secretRef: 'gemini-model'
+            }
+            {
+              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+              value: appInsights.properties.ConnectionString
+            }
+          ]
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 1
+      }
+    }
+  }
+  dependsOn: [
+    aiWorkerAcrPull
+    aiWorkerKeyVaultSecretsUser
+  ]
+}
+
+var migratorSecrets = [
+  {
+    name: 'plannerdb-connection'
+    keyVaultUrl: '${keyVault.properties.vaultUri}secrets/plannerdb-connection'
+    identity: migratorIdentity.id
+  }
+]
+
+var migratorEnv = [
+  {
+    name: 'ConnectionStrings__PlannerDb'
+    secretRef: 'plannerdb-connection'
+  }
+]
+
+resource migrateJob 'Microsoft.App/jobs@2024-03-01' = {
+  name: migrateJobName
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${migratorIdentity.id}': {}
+    }
+  }
+  properties: {
+    environmentId: containerAppsEnvironment.id
+    configuration: {
+      triggerType: 'Manual'
+      replicaTimeout: 1800
+      replicaRetryLimit: 1
+      manualTriggerConfig: {
+        parallelism: 1
+        replicaCompletionCount: 1
+      }
+      registries: [
+        {
+          server: acr.properties.loginServer
+          identity: migratorIdentity.id
+        }
+      ]
+      secrets: migratorSecrets
+    }
+    template: {
+      containers: [
+        {
+          name: 'planner-db-migrator'
+          image: dbMigratorImage
+          command: [
+            'dotnet'
+            'Planner.Tools.DbMigrator.dll'
+          ]
+          args: [
+            'migrate'
+          ]
+          env: migratorEnv
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+        }
+      ]
+    }
+  }
+  dependsOn: [
+    migratorAcrPull
+    migratorKeyVaultSecretsUser
+  ]
+}
+
+resource seedJob 'Microsoft.App/jobs@2024-03-01' = {
+  name: seedJobName
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${migratorIdentity.id}': {}
+    }
+  }
+  properties: {
+    environmentId: containerAppsEnvironment.id
+    configuration: {
+      triggerType: 'Manual'
+      replicaTimeout: 1800
+      replicaRetryLimit: 1
+      manualTriggerConfig: {
+        parallelism: 1
+        replicaCompletionCount: 1
+      }
+      registries: [
+        {
+          server: acr.properties.loginServer
+          identity: migratorIdentity.id
+        }
+      ]
+      secrets: migratorSecrets
+    }
+    template: {
+      containers: [
+        {
+          name: 'planner-db-migrator'
+          image: dbMigratorImage
+          command: [
+            'dotnet'
+            'Planner.Tools.DbMigrator.dll'
+          ]
+          args: [
+            'seed'
+          ]
+          env: migratorEnv
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+        }
+      ]
+    }
+  }
+  dependsOn: [
+    migratorAcrPull
+    migratorKeyVaultSecretsUser
+    migrateJob
+  ]
+}
+
+output keyVaultName string = keyVault.name
+output names object = {
+  acrLoginServer: acr.properties.loginServer
+  acrName: acr.name
+  apiContainerAppName: apiApp.name
+  aiWorkerContainerAppName: aiWorkerApp.name
+  blazorAppName: blazorApp.name
+  containerAppsEnvironmentName: containerAppsEnvironment.name
+  keyVaultName: keyVault.name
+  migrateJobName: migrateJob.name
+  optimizationWorkerContainerAppName: optimizationWorkerApp.name
+  resourceGroupLocation: location
+  seedJobName: seedJob.name
+  sqlDatabaseName: sqlDatabase.name
+  sqlServerName: sqlServer.name
+}
+output githubVariables object = {
+  AZURE_API_CONTAINER_APP_NAME: apiApp.name
+  AZURE_AI_WORKER_CONTAINER_APP_NAME: aiWorkerApp.name
+  AZURE_BLAZOR_APP_NAME: blazorApp.name
+  AZURE_CONTAINER_REGISTRY: acr.properties.loginServer
+  AZURE_CONTAINERAPPS_ENVIRONMENT: containerAppsEnvironment.name
+  AZURE_DB_MIGRATE_JOB_NAME: migrateJob.name
+  AZURE_DB_SEED_JOB_NAME: seedJob.name
+  AZURE_KEY_VAULT_NAME: keyVault.name
+  AZURE_OPTIMIZATION_CONTAINER_APP_NAME: optimizationWorkerApp.name
+  AZURE_RESOURCE_GROUP: resourceGroup().name
+}
+output dnsRecords object = {
+  planner: {
+    host: plannerHostName
+    cnameTarget: blazorApp.properties.defaultHostName
+    txtName: 'asuid.${first(split(plannerHostName, '.'))}'
+    txtValue: blazorApp.properties.customDomainVerificationId
+  }
+  api: {
+    host: apiHostName
+    cnameTarget: apiApp.properties.configuration.ingress.fqdn
+    txtName: 'asuid.${first(split(apiHostName, '.'))}'
+    txtValue: any(apiApp).properties.customDomainVerificationId
+  }
+}

--- a/scripts/azure/bootstrap-entra.ps1
+++ b/scripts/azure/bootstrap-entra.ps1
@@ -1,0 +1,209 @@
+param(
+    [string]$SubscriptionId,
+    [string]$ResourceGroupName = "rg-planner-dev-aue",
+    [string]$KeyVaultName,
+    [string]$Repo = "stephen-wu-chaohui/Planner",
+    [string]$GitHubEnvironment = "dev",
+    [string]$PlannerHostName = "planner.plannerdemo.com",
+    [string]$ApiHostName = "api.plannerdemo.com",
+    [string]$EntraDomain = "plannerdemo.com",
+    [string]$ApiAppDisplayName = "planner-dev-api",
+    [string]$BlazorAppDisplayName = "planner-dev-blazor",
+    [string]$GitHubDeployAppDisplayName = "planner-dev-github-deploy",
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$DemoPassword
+)
+
+$ErrorActionPreference = "Stop"
+
+function Require-Command {
+    param([string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command '$Name' was not found on PATH."
+    }
+}
+
+function Get-AppByDisplayName {
+    param([string]$DisplayName)
+    $json = az ad app list --display-name $DisplayName --query "[0]" -o json
+    if ([string]::IsNullOrWhiteSpace($json) -or $json -eq "null") {
+        return $null
+    }
+    return $json | ConvertFrom-Json
+}
+
+function Ensure-App {
+    param(
+        [string]$DisplayName,
+        [string]$SignInAudience = "AzureADMyOrg"
+    )
+    $app = Get-AppByDisplayName -DisplayName $DisplayName
+    if ($null -eq $app) {
+        Write-Host "Creating app registration '$DisplayName'."
+        $app = az ad app create --display-name $DisplayName --sign-in-audience $SignInAudience -o json | ConvertFrom-Json
+    } else {
+        Write-Host "Using existing app registration '$DisplayName'."
+    }
+
+    az ad sp create --id $app.appId 1>$null 2>$null
+    return Get-AppByDisplayName -DisplayName $DisplayName
+}
+
+function Set-KeyVaultSecret {
+    param(
+        [string]$Name,
+        [string]$Value
+    )
+    if ([string]::IsNullOrWhiteSpace($KeyVaultName)) {
+        return
+    }
+    az keyvault secret set --vault-name $KeyVaultName --name $Name --value $Value --only-show-errors 1>$null
+}
+
+function Set-GraphApplication {
+    param(
+        [string]$ObjectId,
+        [hashtable]$Body
+    )
+    $json = $Body | ConvertTo-Json -Depth 20 -Compress
+    $tempFile = New-TemporaryFile
+    try {
+        $json | Out-File -FilePath $tempFile -Encoding utf8
+        az rest --method PATCH --uri "https://graph.microsoft.com/v1.0/applications/$ObjectId" --headers "Content-Type=application/json" --body "@$tempFile" 1>$null
+    } finally {
+        Remove-Item -LiteralPath $tempFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Require-Command az
+
+if (-not [string]::IsNullOrWhiteSpace($SubscriptionId)) {
+    az account set --subscription $SubscriptionId
+}
+
+$account = az account show --query "{subscriptionId:id, tenantId:tenantId}" -o json | ConvertFrom-Json
+if ([string]::IsNullOrWhiteSpace($SubscriptionId)) {
+    $SubscriptionId = $account.subscriptionId
+}
+$TenantId = $account.tenantId
+
+if ([string]::IsNullOrWhiteSpace($KeyVaultName)) {
+    $KeyVaultName = az keyvault list --resource-group $ResourceGroupName --query "[0].name" -o tsv
+}
+if ([string]::IsNullOrWhiteSpace($KeyVaultName)) {
+    throw "Key Vault name was not provided and could not be discovered in '$ResourceGroupName'."
+}
+
+$apiApp = Ensure-App -DisplayName $ApiAppDisplayName
+$apiIdentifierUri = "api://$($apiApp.appId)"
+$existingApiScope = $apiApp.api.oauth2PermissionScopes | Where-Object { $_.value -eq "API.Access" } | Select-Object -First 1
+$apiScopeId = if ($existingApiScope -and $existingApiScope.id) { $existingApiScope.id } else { [guid]::NewGuid().ToString() }
+
+Set-GraphApplication -ObjectId $apiApp.id -Body @{
+    identifierUris = @($apiIdentifierUri)
+    api = @{
+        requestedAccessTokenVersion = 2
+        oauth2PermissionScopes = @(
+            @{
+                id = $apiScopeId
+                value = "API.Access"
+                type = "User"
+                isEnabled = $true
+                adminConsentDisplayName = "Access Planner API"
+                adminConsentDescription = "Allow Planner clients to access Planner.API."
+                userConsentDisplayName = "Access Planner API"
+                userConsentDescription = "Allow Planner to call Planner.API on your behalf."
+            }
+        )
+    }
+}
+$apiApp = Get-AppByDisplayName -DisplayName $ApiAppDisplayName
+
+$blazorApp = Ensure-App -DisplayName $BlazorAppDisplayName
+Set-GraphApplication -ObjectId $blazorApp.id -Body @{
+    web = @{
+        redirectUris = @("https://$PlannerHostName/signin-oidc")
+    }
+    requiredResourceAccess = @(
+        @{
+            resourceAppId = $apiApp.appId
+            resourceAccess = @(
+                @{
+                    id = $apiScopeId
+                    type = "Scope"
+                }
+            )
+        }
+    )
+}
+$blazorSecret = az ad app credential reset --id $blazorApp.appId --append --display-name "planner-dev-keyvault" --years 1 --query password -o tsv
+az ad app permission admin-consent --id $blazorApp.appId 1>$null
+$blazorApp = Get-AppByDisplayName -DisplayName $BlazorAppDisplayName
+
+$githubApp = Ensure-App -DisplayName $GitHubDeployAppDisplayName
+$subject = "repo:${Repo}:environment:${GitHubEnvironment}"
+$existingFederatedCredential = az ad app federated-credential list --id $githubApp.appId --query "[?name=='github-$GitHubEnvironment'] | [0]" -o json
+if ([string]::IsNullOrWhiteSpace($existingFederatedCredential) -or $existingFederatedCredential -eq "null") {
+    $credential = @{
+        name = "github-$GitHubEnvironment"
+        issuer = "https://token.actions.githubusercontent.com"
+        subject = $subject
+        audiences = @("api://AzureADTokenExchange")
+        description = "GitHub Actions OIDC for $Repo environment $GitHubEnvironment"
+    } | ConvertTo-Json -Depth 10
+
+    $credentialFile = New-TemporaryFile
+    try {
+        $credential | Out-File -FilePath $credentialFile -Encoding utf8
+        az ad app federated-credential create --id $githubApp.appId --parameters "@$credentialFile" 1>$null
+    } finally {
+        Remove-Item -LiteralPath $credentialFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+$githubSpObjectId = az ad sp show --id $githubApp.appId --query id -o tsv
+$resourceGroupId = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName"
+az role assignment create --assignee-object-id $githubSpObjectId --assignee-principal-type ServicePrincipal --role Contributor --scope $resourceGroupId 1>$null 2>$null
+
+$acrId = az acr list --resource-group $ResourceGroupName --query "[0].id" -o tsv
+if (-not [string]::IsNullOrWhiteSpace($acrId)) {
+    az role assignment create --assignee-object-id $githubSpObjectId --assignee-principal-type ServicePrincipal --role AcrPush --scope $acrId 1>$null 2>$null
+}
+
+Set-KeyVaultSecret -Name "azuread-tenant-id" -Value $TenantId
+Set-KeyVaultSecret -Name "azuread-domain" -Value $EntraDomain
+Set-KeyVaultSecret -Name "azuread-api-client-id" -Value $apiApp.appId
+Set-KeyVaultSecret -Name "azuread-blazor-client-id" -Value $blazorApp.appId
+Set-KeyVaultSecret -Name "azuread-blazor-client-secret" -Value $blazorSecret
+Set-KeyVaultSecret -Name "api-scope" -Value "$apiIdentifierUri/API.Access"
+Set-KeyVaultSecret -Name "github-deploy-client-id" -Value $githubApp.appId
+
+$cities = @("taipei", "perth", "sydney", "melbourne", "auckland", "christchurch")
+foreach ($city in $cities) {
+    $upn = "$city.admin@$EntraDomain"
+    $exists = $true
+    az ad user show --id $upn 1>$null 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        $exists = $false
+    }
+
+    if ($exists) {
+        Write-Host "User exists: $upn"
+        continue
+    }
+
+    Write-Host "Creating demo user: $upn"
+    az ad user create `
+        --display-name "$city Planner Admin" `
+        --user-principal-name $upn `
+        --mail-nickname "$city.admin" `
+        --password $DemoPassword `
+        --force-change-password-next-sign-in false `
+        --account-enabled true 1>$null
+}
+
+Write-Host "Entra bootstrap complete."
+Write-Host "GitHub deploy client id: $($githubApp.appId)"
+Write-Host "API client id: $($apiApp.appId)"
+Write-Host "Blazor client id: $($blazorApp.appId)"

--- a/scripts/azure/configure-custom-domains.ps1
+++ b/scripts/azure/configure-custom-domains.ps1
@@ -1,0 +1,47 @@
+param(
+    [string]$ResourceGroupName = "rg-planner-dev-aue",
+    [string]$PlannerHostName = "planner.plannerdemo.com",
+    [string]$ApiHostName = "api.plannerdemo.com",
+    [switch]$Bind
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    throw "Required command 'az' was not found on PATH."
+}
+
+$webAppName = az webapp list --resource-group $ResourceGroupName --query "[0].name" -o tsv
+$webDefaultHostName = az webapp show --resource-group $ResourceGroupName --name $webAppName --query defaultHostName -o tsv
+$webVerificationId = az webapp show --resource-group $ResourceGroupName --name $webAppName --query customDomainVerificationId -o tsv
+
+$apiAppName = "planner-dev-api"
+$apiDefaultHostName = az containerapp show --resource-group $ResourceGroupName --name $apiAppName --query properties.configuration.ingress.fqdn -o tsv
+$apiVerificationId = az containerapp show --resource-group $ResourceGroupName --name $apiAppName --query properties.customDomainVerificationId -o tsv
+
+Write-Host "Create these DNS records with the existing DNS provider:"
+Write-Host ""
+Write-Host "Blazor:"
+Write-Host "  CNAME planner -> $webDefaultHostName"
+Write-Host "  TXT   asuid.planner -> $webVerificationId"
+Write-Host ""
+Write-Host "API:"
+Write-Host "  CNAME api -> $apiDefaultHostName"
+Write-Host "  TXT   asuid.api -> $apiVerificationId"
+Write-Host ""
+
+if (-not $Bind) {
+    Write-Host "After DNS is visible, rerun this script with -Bind."
+    exit 0
+}
+
+Write-Host "Binding App Service custom domain and managed certificate..."
+az webapp config hostname add --resource-group $ResourceGroupName --webapp-name $webAppName --hostname $PlannerHostName 1>$null
+$certThumbprint = az webapp config ssl create --resource-group $ResourceGroupName --name $webAppName --hostname $PlannerHostName --query thumbprint -o tsv
+az webapp config ssl bind --resource-group $ResourceGroupName --name $webAppName --certificate-thumbprint $certThumbprint --ssl-type SNI 1>$null
+
+Write-Host "Binding Container Apps custom domain and managed certificate..."
+az containerapp hostname add --resource-group $ResourceGroupName --name $apiAppName --hostname $ApiHostName 1>$null
+az containerapp hostname bind --resource-group $ResourceGroupName --name $apiAppName --hostname $ApiHostName --validation-method CNAME 1>$null
+
+Write-Host "Custom domain binding complete."

--- a/scripts/azure/configure-github.ps1
+++ b/scripts/azure/configure-github.ps1
@@ -1,0 +1,70 @@
+param(
+    [string]$Repo = "stephen-wu-chaohui/Planner",
+    [string]$GitHubEnvironment = "dev",
+    [string]$SubscriptionId,
+    [string]$TenantId,
+    [string]$ClientId,
+    [string]$ResourceGroupName = "rg-planner-dev-aue",
+    [string]$KeyVaultName
+)
+
+$ErrorActionPreference = "Stop"
+
+foreach ($command in @("az", "gh")) {
+    if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
+        throw "Required command '$command' was not found on PATH."
+    }
+}
+
+if (-not [string]::IsNullOrWhiteSpace($SubscriptionId)) {
+    az account set --subscription $SubscriptionId
+}
+
+$account = az account show --query "{subscriptionId:id, tenantId:tenantId}" -o json | ConvertFrom-Json
+if ([string]::IsNullOrWhiteSpace($SubscriptionId)) {
+    $SubscriptionId = $account.subscriptionId
+}
+if ([string]::IsNullOrWhiteSpace($TenantId)) {
+    $TenantId = $account.tenantId
+}
+if ([string]::IsNullOrWhiteSpace($KeyVaultName)) {
+    $KeyVaultName = az keyvault list --resource-group $ResourceGroupName --query "[0].name" -o tsv
+}
+if ([string]::IsNullOrWhiteSpace($ClientId)) {
+    $ClientId = az keyvault secret show --vault-name $KeyVaultName --name github-deploy-client-id --query value -o tsv
+}
+if ([string]::IsNullOrWhiteSpace($ClientId) -or $ClientId -eq "pending-bootstrap") {
+    throw "GitHub deploy client id was not found. Run bootstrap-entra.ps1 first."
+}
+
+$acrLoginServer = az acr list --resource-group $ResourceGroupName --query "[0].loginServer" -o tsv
+$blazorAppName = az webapp list --resource-group $ResourceGroupName --query "[0].name" -o tsv
+$containerAppsEnvironment = az containerapp env list --resource-group $ResourceGroupName --query "[0].name" -o tsv
+
+$variables = [ordered]@{
+    AZURE_RESOURCE_GROUP = $ResourceGroupName
+    AZURE_CONTAINER_REGISTRY = $acrLoginServer
+    AZURE_CONTAINERAPPS_ENVIRONMENT = $containerAppsEnvironment
+    AZURE_BLAZOR_APP_NAME = $blazorAppName
+    AZURE_API_CONTAINER_APP_NAME = "planner-dev-api"
+    AZURE_OPTIMIZATION_CONTAINER_APP_NAME = "planner-dev-optimization-worker"
+    AZURE_AI_WORKER_CONTAINER_APP_NAME = "planner-dev-ai-worker"
+    AZURE_DB_MIGRATE_JOB_NAME = "planner-dev-db-migrate"
+    AZURE_DB_SEED_JOB_NAME = "planner-dev-db-seed"
+    AZURE_KEY_VAULT_NAME = $KeyVaultName
+}
+
+gh api -X PUT "repos/$Repo/environments/$GitHubEnvironment" 1>$null
+
+gh secret set AZURE_CLIENT_ID --repo $Repo --env $GitHubEnvironment --body $ClientId
+gh secret set AZURE_TENANT_ID --repo $Repo --env $GitHubEnvironment --body $TenantId
+gh secret set AZURE_SUBSCRIPTION_ID --repo $Repo --env $GitHubEnvironment --body $SubscriptionId
+
+foreach ($entry in $variables.GetEnumerator()) {
+    if ([string]::IsNullOrWhiteSpace($entry.Value)) {
+        throw "Value for GitHub variable '$($entry.Key)' is empty."
+    }
+    gh variable set $entry.Key --repo $Repo --env $GitHubEnvironment --body $entry.Value
+}
+
+Write-Host "GitHub environment '$GitHubEnvironment' configured for $Repo."

--- a/scripts/azure/deploy-infra.ps1
+++ b/scripts/azure/deploy-infra.ps1
@@ -1,0 +1,245 @@
+param(
+    [string]$SubscriptionId,
+    [string]$Location = "australiaeast",
+    [string]$ResourceGroupName = "rg-planner-dev-aue",
+    [string]$NamePrefix = "planner-dev",
+    [string]$PlannerHostName = "planner.plannerdemo.com",
+    [string]$ApiHostName = "api.plannerdemo.com",
+    [string]$EntraDomain = "plannerdemo.com",
+    [string]$SqlAdminLogin = "planneradmin",
+    [string]$ApiImage,
+    [string]$OptimizationWorkerImage,
+    [string]$AiWorkerImage,
+    [string]$DbMigratorImage,
+    [switch]$WhatIf
+)
+
+$ErrorActionPreference = "Stop"
+
+function Require-Command {
+    param([string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command '$Name' was not found on PATH."
+    }
+}
+
+function New-RandomPassword {
+    param([int]$Length = 36)
+    $alphabet = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+    -join (1..$Length | ForEach-Object { $alphabet[(Get-Random -Maximum $alphabet.Length)] })
+}
+
+function Get-ExistingKeyVaultName {
+    param([string]$RgName)
+    try {
+        $name = az keyvault list --resource-group $RgName --query "[0].name" -o tsv 2>$null
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($name)) {
+            return $name.Trim()
+        }
+    } catch {
+        return $null
+    }
+    return $null
+}
+
+function Get-KeyVaultSecretValue {
+    param(
+        [string]$VaultName,
+        [string]$SecretName
+    )
+    if ([string]::IsNullOrWhiteSpace($VaultName)) {
+        return $null
+    }
+
+    try {
+        $value = az keyvault secret show --vault-name $VaultName --name $SecretName --query value -o tsv 2>$null
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($value) -and $value -ne "pending-bootstrap") {
+            return $value.Trim()
+        }
+    } catch {
+        return $null
+    }
+    return $null
+}
+
+function Get-CurrentAzurePrincipalObjectId {
+    $currentAccount = az account show -o json | ConvertFrom-Json
+    if ($currentAccount.user.type -eq "user") {
+        return [pscustomobject]@{
+            ObjectId = (az ad signed-in-user show --query id -o tsv).Trim()
+            PrincipalType = "User"
+        }
+    }
+
+    if ($currentAccount.user.type -eq "servicePrincipal") {
+        return [pscustomobject]@{
+            ObjectId = (az ad sp show --id $currentAccount.user.name --query id -o tsv).Trim()
+            PrincipalType = "ServicePrincipal"
+        }
+    }
+
+    return $null
+}
+
+function Get-ExistingContainerAppImage {
+    param(
+        [string]$RgName,
+        [string]$AppName
+    )
+
+    try {
+        $image = az containerapp show --resource-group $RgName --name $AppName --query "properties.template.containers[0].image" -o tsv 2>$null
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($image)) {
+            return $image.Trim()
+        }
+    } catch {
+        return $null
+    }
+
+    return $null
+}
+
+function Get-ExistingContainerAppJobImage {
+    param(
+        [string]$RgName,
+        [string]$JobName
+    )
+
+    try {
+        $image = az containerapp job show --resource-group $RgName --name $JobName --query "properties.template.containers[0].image" -o tsv 2>$null
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($image)) {
+            return $image.Trim()
+        }
+    } catch {
+        return $null
+    }
+
+    return $null
+}
+
+Require-Command az
+
+if (-not [string]::IsNullOrWhiteSpace($SubscriptionId)) {
+    az account set --subscription $SubscriptionId
+}
+
+$account = az account show --query "{subscriptionId:id, tenantId:tenantId}" -o json | ConvertFrom-Json
+if ([string]::IsNullOrWhiteSpace($SubscriptionId)) {
+    $SubscriptionId = $account.subscriptionId
+}
+$TenantId = $account.tenantId
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$templateFile = Join-Path $repoRoot "infra\main.bicep"
+
+$existingKeyVaultName = Get-ExistingKeyVaultName -RgName $ResourceGroupName
+$sqlAdminPassword = Get-KeyVaultSecretValue -VaultName $existingKeyVaultName -SecretName "sql-admin-password"
+$rabbitMqPassword = Get-KeyVaultSecretValue -VaultName $existingKeyVaultName -SecretName "rabbitmq-pass"
+
+if ([string]::IsNullOrWhiteSpace($sqlAdminPassword)) {
+    $sqlAdminPassword = New-RandomPassword
+    Write-Host "Generated a new SQL administrator password."
+} else {
+    Write-Host "Reusing SQL administrator password from Key Vault '$existingKeyVaultName'."
+}
+
+if ([string]::IsNullOrWhiteSpace($rabbitMqPassword)) {
+    $rabbitMqPassword = New-RandomPassword
+    Write-Host "Generated a new RabbitMQ password."
+} else {
+    Write-Host "Reusing RabbitMQ password from Key Vault '$existingKeyVaultName'."
+}
+
+if ([string]::IsNullOrWhiteSpace($ApiImage)) {
+    $ApiImage = Get-ExistingContainerAppImage -RgName $ResourceGroupName -AppName "$NamePrefix-api"
+}
+if ([string]::IsNullOrWhiteSpace($OptimizationWorkerImage)) {
+    $OptimizationWorkerImage = Get-ExistingContainerAppImage -RgName $ResourceGroupName -AppName "$NamePrefix-optimization-worker"
+}
+if ([string]::IsNullOrWhiteSpace($AiWorkerImage)) {
+    $AiWorkerImage = Get-ExistingContainerAppImage -RgName $ResourceGroupName -AppName "$NamePrefix-ai-worker"
+}
+if ([string]::IsNullOrWhiteSpace($DbMigratorImage)) {
+    $DbMigratorImage = Get-ExistingContainerAppJobImage -RgName $ResourceGroupName -JobName "$NamePrefix-db-migrate"
+}
+
+$deploymentName = "planner-dev-" + (Get-Date -Format "yyyyMMddHHmmss")
+$parameters = @(
+    "location=$Location",
+    "resourceGroupName=$ResourceGroupName",
+    "namePrefix=$NamePrefix",
+    "sqlAdminLogin=$SqlAdminLogin",
+    "sqlAdminPassword=$sqlAdminPassword",
+    "rabbitMqPassword=$rabbitMqPassword",
+    "plannerHostName=$PlannerHostName",
+    "apiHostName=$ApiHostName",
+    "entraDomain=$EntraDomain",
+    "entraTenantId=$TenantId"
+)
+
+if (-not [string]::IsNullOrWhiteSpace($ApiImage)) {
+    Write-Host "Using API image: $ApiImage"
+    $parameters += "apiImage=$ApiImage"
+}
+if (-not [string]::IsNullOrWhiteSpace($OptimizationWorkerImage)) {
+    Write-Host "Using optimization worker image: $OptimizationWorkerImage"
+    $parameters += "optimizationWorkerImage=$OptimizationWorkerImage"
+}
+if (-not [string]::IsNullOrWhiteSpace($AiWorkerImage)) {
+    Write-Host "Using AI worker image: $AiWorkerImage"
+    $parameters += "aiWorkerImage=$AiWorkerImage"
+}
+if (-not [string]::IsNullOrWhiteSpace($DbMigratorImage)) {
+    Write-Host "Using DbMigrator image: $DbMigratorImage"
+    $parameters += "dbMigratorImage=$DbMigratorImage"
+}
+
+if ($WhatIf) {
+    az deployment sub what-if `
+        --name $deploymentName `
+        --location $Location `
+        --template-file $templateFile `
+        --parameters $parameters
+    exit $LASTEXITCODE
+}
+
+$outputsJson = az deployment sub create `
+    --name $deploymentName `
+    --location $Location `
+    --template-file $templateFile `
+    --parameters $parameters `
+    --query properties.outputs `
+    -o json
+
+if ($LASTEXITCODE -ne 0) {
+    throw "Bicep deployment failed."
+}
+
+$outputsPath = Join-Path $repoRoot "infra\.last-deployment-outputs.json"
+$outputsJson | Out-File -FilePath $outputsPath -Encoding utf8
+$outputs = $outputsJson | ConvertFrom-Json
+$keyVaultName = $outputs.keyVaultName.value
+
+try {
+    $principal = Get-CurrentAzurePrincipalObjectId
+    if ($null -ne $principal -and -not [string]::IsNullOrWhiteSpace($principal.ObjectId) -and -not [string]::IsNullOrWhiteSpace($keyVaultName)) {
+        $keyVaultId = az keyvault show --name $keyVaultName --query id -o tsv
+        az role assignment create `
+            --assignee-object-id $principal.ObjectId `
+            --assignee-principal-type $principal.PrincipalType `
+            --role "Key Vault Secrets Officer" `
+            --scope $keyVaultId 1>$null 2>$null
+        Write-Host "Granted Key Vault Secrets Officer to the current Azure principal for '$keyVaultName'."
+    }
+} catch {
+    Write-Warning "Could not grant Key Vault Secrets Officer automatically. Grant it manually before running secret bootstrap scripts. $($_.Exception.Message)"
+}
+
+Write-Host "Deployment complete."
+Write-Host "Outputs written to $outputsPath"
+Write-Host ""
+Write-Host "Next:"
+Write-Host "  1. Run scripts/azure/bootstrap-entra.ps1"
+Write-Host "  2. Run scripts/azure/set-runtime-secrets.ps1 with rotated Google/Firebase/Gemini/Maps values"
+Write-Host "  3. Run scripts/azure/configure-github.ps1"
+Write-Host "  4. Run scripts/azure/configure-custom-domains.ps1 and add DNS records"

--- a/scripts/azure/set-runtime-secrets.ps1
+++ b/scripts/azure/set-runtime-secrets.ps1
@@ -1,0 +1,52 @@
+param(
+    [string]$ResourceGroupName = "rg-planner-dev-aue",
+    [string]$KeyVaultName,
+    [string]$FirestoreProjectId,
+    [string]$FirebaseConfigJsonPath,
+    [string]$FirebaseConfigJsonBase64,
+    [string]$GoogleApiKey,
+    [string]$GoogleMapsApiKey,
+    [string]$GoogleMapsMapId,
+    [string]$GeminiApiKey,
+    [string]$GeminiModel = "gemini-2.5-flash"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    throw "Required command 'az' was not found on PATH."
+}
+
+if ([string]::IsNullOrWhiteSpace($KeyVaultName)) {
+    $KeyVaultName = az keyvault list --resource-group $ResourceGroupName --query "[0].name" -o tsv
+}
+if ([string]::IsNullOrWhiteSpace($KeyVaultName)) {
+    throw "Key Vault name was not provided and could not be discovered in '$ResourceGroupName'."
+}
+
+if ([string]::IsNullOrWhiteSpace($FirebaseConfigJsonBase64) -and -not [string]::IsNullOrWhiteSpace($FirebaseConfigJsonPath)) {
+    $rawJson = Get-Content -LiteralPath $FirebaseConfigJsonPath -Raw
+    $FirebaseConfigJsonBase64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($rawJson))
+}
+
+$values = [ordered]@{
+    "firestore-project-id" = $FirestoreProjectId
+    "firebase-config-json" = $FirebaseConfigJsonBase64
+    "google-api-key" = $GoogleApiKey
+    "google-maps-api-key" = $GoogleMapsApiKey
+    "google-maps-map-id" = $GoogleMapsMapId
+    "gemini-api-key" = $GeminiApiKey
+    "gemini-model" = $GeminiModel
+}
+
+foreach ($entry in $values.GetEnumerator()) {
+    if ([string]::IsNullOrWhiteSpace($entry.Value)) {
+        Write-Host "Skipping '$($entry.Key)' because no value was provided."
+        continue
+    }
+
+    az keyvault secret set --vault-name $KeyVaultName --name $entry.Key --value $entry.Value --only-show-errors 1>$null
+    Write-Host "Updated Key Vault secret '$($entry.Key)'."
+}
+
+Write-Host "Runtime secret update complete."

--- a/src/Planner.AI/planner_ai_worker.py
+++ b/src/Planner.AI/planner_ai_worker.py
@@ -48,7 +48,8 @@ class PlannerAIWorker:
     def __init__(self):
         """Initialize the worker with Firestore and Gemini configurations."""
         self.db = None
-        self.model = None
+        self.client = None
+        self.model_name = os.getenv('GEMINI_MODEL', 'gemini-2.5-flash')
         self._initialize_firestore()
         self._initialize_gemini()
         logger.info("Planner.AI Worker initialized successfully")
@@ -104,7 +105,6 @@ class PlannerAIWorker:
             from google import genai
             self.client = genai.Client() # It will automatically use the GEMINI_API_KEY from environment variables
             # Initialize the model (gemini-2.0-flash-exp or gemini-2.0-flash)
-            self.model_name = os.getenv('GEMINI_MODEL', 'gemini-2.5-flash')
             response = self.client.models.generate_content(
                 model=self.model_name, 
                 contents="Hello world"
@@ -114,7 +114,8 @@ class PlannerAIWorker:
             
         except Exception as e:
             logger.error(f"Failed to initialize Gemini: {e}")
-            raise
+            logger.warning("Gemini analysis will use fallback text until GEMINI_API_KEY is rotated.")
+            self.client = None
     
     def _construct_analysis_prompt(self, json_payload: str) -> str:
         """
@@ -147,6 +148,9 @@ Format your response in markdown with clear sections."""
             Analysis text from Gemini
         """
         try:
+            if self.client is None:
+                return "## Analysis Unavailable\n\nGemini is not configured with a valid API key. Rotate GEMINI_API_KEY to enable AI-generated route insights."
+
             prompt = self._construct_analysis_prompt(json_payload)
             response = self.client.models.generate_content(
                 model=self.model_name,

--- a/tools/Planner.Tools.DbMigrator/Dockerfile
+++ b/tools/Planner.Tools.DbMigrator/Dockerfile
@@ -1,0 +1,29 @@
+# -------- Build stage --------
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY tools/Planner.Tools.DbMigrator/Planner.Tools.DbMigrator.csproj tools/Planner.Tools.DbMigrator/
+COPY src/Planner.Application/Planner.Application.csproj src/Planner.Application/
+COPY src/Planner.Domain/Planner.Domain.csproj src/Planner.Domain/
+COPY src/Planner.Infrastructure/Planner.Infrastructure.csproj src/Planner.Infrastructure/
+
+RUN dotnet restore tools/Planner.Tools.DbMigrator/Planner.Tools.DbMigrator.csproj
+
+COPY src/ src/
+COPY tools/Planner.Tools.DbMigrator/ tools/Planner.Tools.DbMigrator/
+
+RUN dotnet publish tools/Planner.Tools.DbMigrator/Planner.Tools.DbMigrator.csproj \
+    -c Release \
+    -o /app/publish \
+    --no-restore \
+    /p:UseAppHost=false
+
+# -------- Runtime stage --------
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+USER app
+
+COPY --from=build /app/publish .
+
+ENTRYPOINT ["dotnet", "Planner.Tools.DbMigrator.dll"]
+CMD ["migrate"]


### PR DESCRIPTION
## Summary

Adds a repeatable Azure dev deployment path for Planner:

- adds Bicep infrastructure for the dev resource group, Container Apps, App Service, Key Vault, ACR, SQL, RabbitMQ, and DbMigrator jobs
- adds PowerShell bootstrap scripts for infra deployment, Entra app setup, runtime secrets, GitHub environment variables/secrets, and custom domains
- updates GitHub Actions to use Azure OIDC, environment variables, ACR image publishing, Container Apps updates, and DbMigrator jobs
- adds a DbMigrator Dockerfile and a new subscription deployment runbook
- makes Planner.AI tolerate a missing/rotated Gemini key by returning fallback analysis text instead of crashing

## Notes

The bootstrap script now requires `-DemoPassword` explicitly rather than shipping a default demo-user password. Generated `infra/main.json` and local deployment outputs are ignored.

## Validation

- `az bicep build --file infra/main.bicep --outfile $env:TEMP/planner-main.validate.json`
- PowerShell parser check for `scripts/azure/*.ps1`
- `python -m py_compile src/Planner.AI/planner_ai_worker.py`
- `dotnet build tools/Planner.Tools.DbMigrator/Planner.Tools.DbMigrator.csproj -c Release`
- workflow YAML parse via temp-installed `yaml` npm package
- `git diff --cached --check`

`dotnet build` completed with one existing nullability warning in `src/Planner.Infrastructure/TenantContext.cs`.