### PR TITLE
[codex] upgrade actions to Node 24

### DIFF
--- a/.github/workflows/db-migrator-dev.yml
+++ b/.github/workflows/db-migrator-dev.yml
@@ -45,24 +45,24 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to ACR (OIDC)
         run: |
           az acr login --name $(echo "${AZURE_CONTAINER_REGISTRY}" | cut -d'.' -f1)
 
       - name: Build and push DbMigrator image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: tools/Planner.Tools.DbMigrator/Dockerfile
@@ -72,13 +72,13 @@ jobs:
             ${{ env.AZURE_CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
       - name: Install Azure Container Apps extension
-        uses: azure/CLI@v2
+        uses: azure/CLI@v3
         with:
           inlineScript: |
             az extension add --name containerapp --upgrade
 
       - name: Run DbMigrator jobs
-        uses: azure/CLI@v2
+        uses: azure/CLI@v3
         env:
           DB_COMMAND: ${{ github.event.inputs.command || 'migrate-and-seed' }}
         with:

--- a/.github/workflows/deploy-planner-ai-worker.yml
+++ b/.github/workflows/deploy-planner-ai-worker.yml
@@ -25,24 +25,24 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to ACR (OIDC)
         run: |
           az acr login --name $(echo "${AZURE_CONTAINER_REGISTRY}" | cut -d'.' -f1)
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: src/Planner.AI
           file: src/Planner.AI/Dockerfile
@@ -52,13 +52,13 @@ jobs:
             ${{ env.AZURE_CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
       - name: Install Azure Container Apps extension
-        uses: azure/CLI@v2
+        uses: azure/CLI@v3
         with:
           inlineScript: |
             az extension add --name containerapp --upgrade
 
       - name: Deploy to Azure Container Apps
-        uses: azure/CLI@v2
+        uses: azure/CLI@v3
         with:
           inlineScript: |
             set -eo pipefail

--- a/.github/workflows/deploy-planner-api-aca.yml
+++ b/.github/workflows/deploy-planner-api-aca.yml
@@ -33,24 +33,24 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to ACR (OIDC)
         run: |
           az acr login --name $(echo "${AZURE_CONTAINER_REGISTRY}" | cut -d'.' -f1)
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: src/Planner.API/Dockerfile
@@ -60,13 +60,13 @@ jobs:
             ${{ env.AZURE_CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
       - name: Install Azure Container Apps extension
-        uses: azure/CLI@v2
+        uses: azure/CLI@v3
         with:
           inlineScript: |
             az extension add --name containerapp --upgrade
 
       - name: Deploy to Azure Container Apps
-        uses: azure/CLI@v2
+        uses: azure/CLI@v3
         with:
           inlineScript: |
             set -eo pipefail

--- a/.github/workflows/deploy-planner-optimization-worker-aca.yml
+++ b/.github/workflows/deploy-planner-optimization-worker-aca.yml
@@ -32,24 +32,24 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to ACR (OIDC)
         run: |
           az acr login --name $(echo "${AZURE_CONTAINER_REGISTRY}" | cut -d'.' -f1)
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: src/Planner.Optimization.Worker/Dockerfile
@@ -59,13 +59,13 @@ jobs:
             ${{ env.AZURE_CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
       - name: Install Azure Container Apps extension
-        uses: azure/CLI@v2
+        uses: azure/CLI@v3
         with:
           inlineScript: |
             az extension add --name containerapp --upgrade
 
       - name: Deploy to Azure Container Apps
-        uses: azure/CLI@v2
+        uses: azure/CLI@v3
         with:
           inlineScript: |
             set -eo pipefail

--- a/.github/workflows/main_planner-blazor-dev.yml
+++ b/.github/workflows/main_planner-blazor-dev.yml
@@ -24,15 +24,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Summary

Updates GitHub Actions workflow action pins so the JavaScript-based actions run on Node 24 instead of Node 20.

Changed actions include checkout, setup-dotnet, azure/login, docker/setup-buildx-action, docker/build-push-action, and azure/CLI across the deployment workflows. `azure/webapps-deploy@v3` was left unchanged because its upstream action metadata already declares Node 24.

## Impact

Avoids GitHub Actions Node 20 deprecation warnings and keeps CI/CD workflow actions on the supported Node 24 runtime.

## Validation

- Verified each remaining workflow `uses:` action reports `using: node24` from upstream action metadata.
- Ran `git diff --cached --check` successfully before committing.
- Confirmed no remaining workflow references to the old Node 20-backed action versions.