### PR TITLE
[codex] fix db migrator job start

### DIFF
--- a/.github/workflows/db-migrator-dev.yml
+++ b/.github/workflows/db-migrator-dev.yml
@@ -86,6 +86,48 @@ jobs:
             set -eo pipefail
 
             IMAGE_TAG="${AZURE_CONTAINER_REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}"
+            JOB_CONTAINER_NAME="planner-db-migrator"
+
+            dump_job_logs() {
+              local job_name="$1"
+              local execution_name="$2"
+              local environment_id
+              local workspace_id
+              local log_query
+
+              echo "::group::$job_name/$execution_name logs"
+              az containerapp job logs show \
+                --name "$job_name" \
+                --resource-group "$AZURE_RESOURCE_GROUP" \
+                --execution "$execution_name" \
+                --container "$JOB_CONTAINER_NAME" \
+                --tail 300 \
+                --format text || true
+
+              environment_id="$(az containerapp job show \
+                --name "$job_name" \
+                --resource-group "$AZURE_RESOURCE_GROUP" \
+                --query properties.environmentId \
+                -o tsv 2>/dev/null || true)"
+
+              if [ -n "$environment_id" ]; then
+                workspace_id="$(az containerapp env show \
+                  --ids "$environment_id" \
+                  --query properties.appLogsConfiguration.logAnalyticsConfiguration.customerId \
+                  -o tsv 2>/dev/null || true)"
+              fi
+
+              if [ -n "${workspace_id:-}" ]; then
+                sleep 20
+                log_query="ContainerAppConsoleLogs_CL | where TimeGenerated > ago(2h) | where ContainerJobName_s == '$job_name' and ContainerGroupName_s startswith '$execution_name' | project TimeGenerated, Stream_s, Log_s | order by TimeGenerated asc"
+                az monitor log-analytics query \
+                  --workspace "$workspace_id" \
+                  --analytics-query "$log_query" \
+                  -o table || true
+              fi
+
+              echo "::endgroup::"
+            }
 
             wait_for_job() {
               local job_name="$1"
@@ -106,6 +148,7 @@ jobs:
                 fi
 
                 if [ "$status" = "Failed" ] || [ "$status" = "Canceled" ]; then
+                  dump_job_logs "$job_name" "$execution_name"
                   return 1
                 fi
 
@@ -113,6 +156,7 @@ jobs:
               done
 
               echo "Timed out waiting for $job_name/$execution_name"
+              dump_job_logs "$job_name" "$execution_name"
               return 1
             }
 
@@ -127,7 +171,6 @@ jobs:
               execution_name="$(az containerapp job start \
                 --name "$job_name" \
                 --resource-group "$AZURE_RESOURCE_GROUP" \
-                --image "$IMAGE_TAG" \
                 --query name \
                 -o tsv)"
 

--- a/tools/Planner.Tools.DbMigrator/SeedScripts/002_Add_DemoUsers.sql
+++ b/tools/Planner.Tools.DbMigrator/SeedScripts/002_Add_DemoUsers.sql
@@ -32,7 +32,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM Users u
     WHERE u.TenantId = t.Id
-      AND u.Email = LOWER(t.Name) + '@demo.local'
+      AND u.Email = LOWER(t.Name) + '.admin@demo.local'
 );
 
 -- Insert Normal users


### PR DESCRIPTION
## Summary

Fixes the dev database migrator workflow so Container Apps jobs start from the updated job template instead of using a start-time image override that drops configured environment/secret refs.

## Root Cause

The workflow first updated the job image, then called `az containerapp job start --image ...`. The start-time image override produced executions without the configured `ConnectionStrings__PlannerDb` secret reference, so the migrator exited with `Connection string 'PlannerDb' not found.`

## Changes

- Start the updated Container Apps job without the `--image` override so the configured template env and Key Vault secret refs are preserved.
- Dump Container Apps job logs and Log Analytics console logs when a job fails or times out.
- Fix the admin demo-user seed idempotency check to match the email inserted by the script.

## Validation

- `dotnet build tools\Planner.Tools.DbMigrator\Planner.Tools.DbMigrator.csproj --no-restore` passes.
- Workflow shell block parses with `bash -n`.

The build currently reports one existing nullability warning in `src/Planner.Infrastructure/TenantContext.cs`.