### PR TITLE
[codex] Set Container Apps min replicas to zero

### DIFF
--- a/infra/modules/core.bicep
+++ b/infra/modules/core.bicep
@@ -609,7 +609,7 @@ resource rabbitMqApp 'Microsoft.App/containerApps@2024-03-01' = {
         }
       ]
       scale: {
-        minReplicas: 1
+        minReplicas: 0
         maxReplicas: 1
       }
       volumes: [
@@ -791,7 +791,7 @@ resource apiApp 'Microsoft.App/containerApps@2024-03-01' = {
         }
       ]
       scale: {
-        minReplicas: 1
+        minReplicas: 0
         maxReplicas: 3
       }
     }
@@ -873,7 +873,7 @@ resource optimizationWorkerApp 'Microsoft.App/containerApps@2024-03-01' = {
         }
       ]
       scale: {
-        minReplicas: 1
+        minReplicas: 0
         maxReplicas: 1
       }
     }
@@ -956,7 +956,7 @@ resource aiWorkerApp 'Microsoft.App/containerApps@2024-03-01' = {
         }
       ]
       scale: {
-        minReplicas: 1
+        minReplicas: 0
         maxReplicas: 1
       }
     }


### PR DESCRIPTION
## Summary

Set the Azure Container Apps `scale.minReplicas` property to `0` for the deployed Planner Container Apps defined in Bicep:

- `rabbitMqApp`
- `apiApp`
- `optimizationWorkerApp`
- `aiWorkerApp`

## Why

This allows the Container Apps deployment to scale down to zero replicas when idle, matching the live Azure update that was applied manually.

## Validation

- `az bicep build --file infra\main.bicep`
- Verified live Azure Container App settings in `rg-planner-dev-aue` show `minReplicas` as `0` for all four apps.