### PR TITLE
[codex] Support named Firestore database for local AI flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ FIREBASE_CONFIG_JSON=ey...
 # Example: abundantlife-215910
 FIRESTORE_PROJECT_ID=your_firebase_project_id_here
 
+# Optional Firestore database id. Leave blank for the default database.
+# Example: planner
+FIRESTORE_DATABASE_ID=
+
 # Async optimization path. Default stays RabbitMq; set AzureServiceBus to test the new path.
 OPTIMIZATION_DISPATCH_MODE=RabbitMq
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - AzureAd__TenantId=common
       - AzureAd__ClientId=8621f365-5e51-4b25-931a-1c717ead22ac
       - Firestore__ProjectId=${FIRESTORE_PROJECT_ID}
+      - Firestore__DatabaseId=${FIRESTORE_DATABASE_ID}
       - Cosmos__ConnectionString=${COSMOS_CONNECTION_STRING}
       - Cosmos__DatabaseName=planner
       - Cosmos__OptimizationRunsContainerName=optimizationRuns
@@ -163,9 +164,9 @@ services:
     container_name: planner-ai-worker
     environment:
       - PYTHONUNBUFFERED=1
-      - GOOGLE_API_KEY=${GOOGLE_API_KEY}
       - GEMINI_API_KEY=${GEMINI_API_KEY}
       - GEMINI_MODEL=${GEMINI_MODEL}
+      - FIRESTORE_DATABASE_ID=${FIRESTORE_DATABASE_ID}
       - FIREBASE_CONFIG_JSON=${FIREBASE_CONFIG_JSON}
     restart: unless-stopped
 

--- a/src/Planner.AI/planner_ai_worker.py
+++ b/src/Planner.AI/planner_ai_worker.py
@@ -91,8 +91,13 @@ class PlannerAIWorker:
                     print(f"Failed to initialize Firebase: {e}")
                     
             # Get Firestore client
-            self.db = firestore.client()
-            logger.info("Firestore client initialized")
+            database_id = os.getenv('FIRESTORE_DATABASE_ID')
+            if database_id:
+                self.db = firestore.client(database_id=database_id)
+                logger.info("Firestore client initialized for database '%s'", database_id)
+            else:
+                self.db = firestore.client()
+                logger.info("Firestore client initialized")
             
         except Exception as e:
             logger.error(f"Failed to initialize Firestore: {e}")

--- a/src/Planner.Messaging/Firestore/FirestoreConnectionFactory.cs
+++ b/src/Planner.Messaging/Firestore/FirestoreConnectionFactory.cs
@@ -29,6 +29,7 @@ public sealed class FirestoreConnectionFactory(IConfiguration configuration, ILo
             }
 
             var projectId = configuration["Firestore:ProjectId"];
+            var databaseId = configuration["Firestore:DatabaseId"];
             var base64Json = configuration["FIREBASE_CONFIG_JSON"];
 
             if (string.IsNullOrEmpty(base64Json))
@@ -73,8 +74,16 @@ public sealed class FirestoreConnectionFactory(IConfiguration configuration, ILo
                     ProjectId = projectId,
                     JsonCredentials = finalJson
                 };
+                if (!string.IsNullOrWhiteSpace(databaseId))
+                {
+                    builder.DatabaseId = databaseId;
+                }
+
                 _db = builder.Build();
-                logger.LogInformation("FirestoreDb instance created successfully for project {ProjectId}.", projectId);
+                logger.LogInformation(
+                    "FirestoreDb instance created successfully for project {ProjectId}, database {DatabaseId}.",
+                    projectId,
+                    string.IsNullOrWhiteSpace(databaseId) ? "(default)" : databaseId);
                 return _db;
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary

Supports the interim Firebase-backed Planner.AI flow while the project migrates toward an Azure-native Cosmos-backed implementation.

This keeps local runs testable by allowing the API and AI worker to use the same named Firestore database instead of always targeting the default database.

Closes #75.

## Changes

- Add optional `Firestore:DatabaseId` support to the shared .NET Firestore connection factory.
- Add optional `FIRESTORE_DATABASE_ID` support to Planner.AI's Firestore client.
- Pass the database id through local Docker Compose for API and Planner.AI.
- Stop passing `GOOGLE_API_KEY` into Planner.AI so the Gemini SDK uses `GEMINI_API_KEY`.
- Document the optional `FIRESTORE_DATABASE_ID` setting in `.env.example`.

## Validation

- `python -m py_compile src/Planner.AI/planner_ai_worker.py`
- `dotnet build src/Planner.Messaging/Planner.Messaging.csproj`
- `GET http://localhost:5000/health` returned `200 Healthy`
- `docker compose ps planner-ai-worker planner-api planner-optimization-worker rabbitmq sqlserver` showed all services up
- Firestore smoke test through `planner-ai-worker`: temporary `pending_analysis` document was processed, matching `route_insights` document was written, and input status became `processed`

## Notes

Gemini remains blocked locally by current API key restrictions (`API_KEY_SERVICE_BLOCKED`), so Planner.AI falls back to the existing unavailable-analysis text. Firestore input/output and Blazor notification are working locally.