### PR TITLE
[codex] Document Azure migration workflow and delivery rules

### DIFF
--- a/.env.azure.example
+++ b/.env.azure.example
@@ -1,0 +1,39 @@
+# Azure migration environment template.
+# Copy this file to .env.azure.local and put local or subscription-specific values there.
+# Current scripts are parameter-driven; this file is a shared source of values for the migration plan and command setup.
+
+# Azure deployment script inputs
+AZURE_SUBSCRIPTION_ID=
+AZURE_LOCATION=australiaeast
+AZURE_RESOURCE_GROUP=rg-planner-dev-aue
+AZURE_NAME_PREFIX=planner-dev
+AZURE_PLANNER_HOST_NAME=planner.plannerdemo.com
+AZURE_API_HOST_NAME=api.plannerdemo.com
+AZURE_ENTRA_DOMAIN=plannerdemo.com
+AZURE_SQL_ADMIN_LOGIN=planneradmin
+AZURE_KEY_VAULT_NAME=
+
+# GitHub and Entra bootstrap inputs
+AZURE_GITHUB_REPO=stephen-wu-chaohui/Planner
+AZURE_GITHUB_ENVIRONMENT=dev
+ENTRA_DEMO_PASSWORD=
+
+# Runtime secrets for Key Vault bootstrap
+FIRESTORE_PROJECT_ID=
+FIREBASE_CONFIG_JSON_PATH=
+FIREBASE_CONFIG_JSON_BASE64=
+GOOGLE_API_KEY=
+GOOGLE_MAPS_API_KEY=
+GOOGLE_MAPS_MAP_ID=
+GEMINI_API_KEY=
+GEMINI_MODEL=gemini-2.5-flash
+
+# Local Azure-native runtime switches and emulator values
+OPTIMIZATION_DISPATCH_MODE=AzureServiceBus
+REALTIME__PROVIDER=SignalR
+SERVICEBUS_CONNECTION_STRING=Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
+COSMOS_CONNECTION_STRING=AccountEndpoint=https://localhost:8081/;AccountKey=replace_with_cosmos_emulator_key;
+COSMOS_DISABLE_SERVER_CERTIFICATE_VALIDATION=true
+AZURE_SIGNALR_CONNECTION_STRING=
+SignalR__ConnectionString=
+SignalR__HubName=planner

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 
 # dotenv files
 .env
+.env.local
+.env.*.local
+.env.azure
 
 # Firebase credentials (sensitive)
 *firebase-credentials.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# Planner Agent Instructions
+
+## Architecture direction
+
+Planner is a multi-tenant route optimization platform.
+
+The target architecture is:
+
+- SQL Server + EF Core remain the source of truth for long-lived master data:
+  - Tenants
+  - Vehicles
+  - Depots
+  - Jobs
+  - accepted/published Routes
+
+- Cosmos DB stores optimization run lifecycle documents:
+  - request snapshot
+  - status
+  - solver result
+  - AI insight
+  - timeline
+  - execution attempts
+
+- Azure Service Bus is the command queue.
+  - Messages should be lightweight.
+  - Optimization job messages must contain tenantId and optimizationRunId only.
+  - Do not put full OptimizeRouteRequest payloads into Service Bus messages.
+
+- Optimization execution is handled by a Container Apps Job-style worker.
+  - The worker consumes Service Bus messages.
+  - The worker reads OptimizationRun documents from Cosmos DB.
+  - The worker calls VehicleRoutingProblem.Optimize(...)
+  - The worker writes status/result back to Cosmos DB.
+  - The worker must not call Planner.Api to fetch requests or return results.
+
+- Planner.Reactor / Functions App is a reaction layer around Cosmos DB.
+  - It listens to Cosmos DB Change Feed.
+  - It publishes lightweight SignalR notifications.
+  - It may handle AI insight triggers, DLQ processing, cleanup, and stuck-run recovery.
+  - It must not become a user-facing query API.
+
+- Planner.Api remains the user-facing command/query control plane.
+  - It handles authentication, tenant authorization, quota checks, run creation, status queries, result queries, and route acceptance.
+  - BlazorApp must call Planner.Api for full result data.
+  - SignalR messages should notify that something changed; they should not be treated as the authoritative data source.
+
+## Multi-tenancy rules
+
+- Tenant isolation is mandatory.
+- All SQL queries must be tenant-scoped.
+- Cosmos DB OptimizationRuns must use tenantId as the partition key.
+- Service Bus messages must include tenantId.
+- SignalR notifications must be tenant-scoped.
+- Never implement a method that retrieves tenant data by runId alone without tenantId.
+
+## Migration rules
+
+- Do not remove the existing RabbitMQ workflow until the new Service Bus + Cosmos workflow is verified.
+- Prefer feature flags for switching between old and new workflow paths.
+- Keep changes incremental and testable.
+
+## Blazor rules
+
+- SignalR messages should update local summary state.
+- Blazor should call Planner.Api for full result/AI insight data only when needed.
+- Use @key for rendered run lists, using OptimizationRunId.
+- Avoid automatically pulling full result data for every SignalR notification.
+
+## Testing expectations
+
+Before completing a task, run:
+
+```bash
+dotnet build
+dotnet test

--- a/docs/architecture/optimization-workflow-redesign.md
+++ b/docs/architecture/optimization-workflow-redesign.md
@@ -1,0 +1,47 @@
+We are refactoring Planner from the current RabbitMQ request/result flow into an Azure-native asynchronous optimization architecture.
+
+Current high-level behavior:
+- API currently sends optimization requests to RabbitMQ.
+- Worker consumes the request, solves the route optimization, and sends the result back through RabbitMQ.
+- API persists the result for BlazorApp / AI Worker consumption.
+- SQL Server + EF Core already store Tenants, Vehicles, Depots, Jobs, and Routes.
+
+Target architecture:
+- Keep SQL Server + EF Core as the source of truth for long-lived master data: Tenants, Vehicles, Depots, Jobs, accepted/published Routes.
+- Add Cosmos DB as the source of truth for each OptimizationRun lifecycle: request snapshot, status, solver result, AI insight, timeline, execution attempts.
+- Add Azure Service Bus as the command queue. The API sends only { tenantId, optimizationRunId }.
+- Add a Container Apps Job-style worker project that consumes one Service Bus message, loads the OptimizationRun from Cosmos DB, calls the existing VehicleRoutingProblem.Optimize(request), saves the result/status back to Cosmos DB, and completes/abandons/dead-letters the message appropriately.
+- Add a Planner.Reactor Functions App that listens to Cosmos DB Change Feed and publishes lightweight SignalR notifications.
+- BlazorApp receives SignalR notifications, updates local summary state, and calls Planner.Api for full result only when needed.
+- API remains the user-facing command/query control plane.
+- Planner.Reactor is not a user-facing query API.
+
+Please inspect the repository and produce an implementation plan only. Do not modify files yet.
+
+The plan must include:
+1. Existing projects/files that should be changed.
+2. New projects that should be added.
+3. Proposed data contracts:
+   - OptimizationRunDocument
+   - OptimizationRunStatus
+   - OptimizationJobMessage
+   - SignalR event DTOs
+4. Proposed service interfaces:
+   - IOptimizationRunStore
+   - IOptimizationJobQueue
+   - IOptimizationRunSnapshotBuilder
+5. Proposed local development setup.
+6. A safe migration strategy that keeps the existing RabbitMQ path working until the new path is verified.
+7. Test plan:
+   - unit tests
+   - integration tests
+   - local manual test steps
+8. Risks and open questions.
+
+Important constraints:
+- Do not remove the existing RabbitMQ implementation in the first PR.
+- Do not move Tenant/Vehicles/Depots/Jobs master data out of SQL Server.
+- Do not make Functions App a middleman between API and Worker.
+- Worker must not call API to get request data or return result.
+- Worker reads/writes Cosmos DB directly.
+- SignalR messages must be lightweight; BlazorApp should call API for full result.

--- a/docs/codex-workflows.md
+++ b/docs/codex-workflows.md
@@ -1,0 +1,86 @@
+## `/shipit` workflow
+
+When the user says `/shipit`, treat it as a request to complete the full GitHub delivery workflow for the current approved change.
+
+The workflow means:
+
+1. Inspect the current repository state.
+
+   * Check current branch.
+   * Check `git status`.
+   * Review the diff.
+   * Identify changed files.
+   * Confirm there are no unrelated or accidental changes.
+
+2. Create or update a GitHub issue.
+
+   * If the user has already given an issue number, use it.
+   * Otherwise create a new GitHub issue describing the change.
+   * The issue should include:
+
+     * problem / goal
+     * implementation scope
+     * acceptance criteria
+     * test plan
+
+3. Create a feature branch.
+
+   * Branch from the correct base branch, usually `main`.
+   * Use a clear branch name, for example:
+
+     * `feature/<issue-number>-short-description`
+     * `fix/<issue-number>-short-description`
+   * Do not work directly on `main`.
+
+4. Implement or finalize the change.
+
+   * Keep the scope limited to the issue.
+   * Do not perform unrelated refactoring.
+   * Follow the architecture rules in `AGENTS.md`.
+   * Preserve existing behavior unless the issue explicitly changes it.
+
+5. Run validation.
+
+   * Run `dotnet build`.
+   * Run `dotnet test`.
+   * If frontend code changed, run the relevant frontend build/test command.
+   * If some tests cannot be run locally, explain exactly why.
+
+6. Commit the change.
+
+   * Stage only relevant files.
+   * Use a clear commit message.
+   * Prefer a message linked to the issue, for example:
+
+     * `feat: add optimization run Cosmos document store`
+     * `fix: handle completed run SignalR updates`
+
+7. Push the branch to GitHub.
+
+8. Open a draft pull request against `main`.
+
+   * Link the GitHub issue.
+   * Include:
+
+     * summary of changes
+     * architecture notes if relevant
+     * test results
+     * risks / follow-up work
+   * Keep the PR as Draft unless the user explicitly says it is ready for review.
+
+9. Report back with:
+
+   * issue link
+   * branch name
+   * PR link
+   * build/test results
+   * any unresolved risks or manual verification still needed
+
+Important rules:
+
+* Never push directly to `main`.
+* Never include secrets in commits.
+* Never include unrelated formatting or refactoring.
+* Do not delete the old RabbitMQ workflow unless the issue explicitly says so.
+* Prefer small, reviewable PRs.
+* If the working tree contains unrelated changes, stop and ask how to handle them before committing.


### PR DESCRIPTION
Closes #78

## Summary
- Added repo-level `AGENTS.md` guidance for the Azure-native Planner migration, tenant isolation rules, Blazor behavior, and required validation commands.
- Added `.env.azure.example` with sanitized Azure migration placeholders and updated `.gitignore` so local Azure env files stay untracked.
- Added `docs/codex-workflows.md` documenting the `/shipit` issue, branch, validation, commit, push, and draft PR workflow.
- Added `docs/architecture/optimization-workflow-redesign.md` as the planning prompt for the Azure-native optimization workflow redesign.

## Architecture Notes
- Documents SQL Server + EF Core as the source of truth for long-lived master data.
- Documents Cosmos DB as the source for optimization run lifecycle documents using tenantId as partition key.
- Documents Service Bus optimization messages as lightweight `{ tenantId, optimizationRunId }` commands.
- Preserves the existing RabbitMQ workflow during migration and keeps Planner.Api as the user-facing control plane.

## Validation
- `dotnet build` passed after stopping a stale local `Planner.BlazorApp.exe` process that was locking Debug output DLLs.
- `dotnet test` passed; discovered tests passed, and two assemblies reported no tests available.
- Reviewed changed files for accidental secrets; only placeholder values are present in `.env.azure.example`.

## Risks / Follow-up
- This is documentation/configuration only; no Azure runtime path is implemented here.
- The architecture redesign document is a planning prompt and still needs the actual implementation plan in a follow-up change.