### PR TITLE
[codex] Wire Service Bus Cosmos optimization path

### DIFF
--- a/src/Planner.API/Program.cs
+++ b/src/Planner.API/Program.cs
@@ -11,6 +11,7 @@ using Planner.Application.OptimizationRuns;
 using Planner.Infrastructure;
 using Planner.Infrastructure.Coordinator;
 using Planner.Messaging;
+using Planner.Messaging.Messaging;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -22,6 +23,7 @@ builder.Configuration
     .AddEnvironmentVariables();
 
 ValidateRequiredConfiguration(builder.Configuration);
+var useAzureOptimizationDispatch = UseAzureServiceBusDispatch(builder.Configuration);
 
 // ────────────────────────────────────────────────
 // Logging
@@ -70,12 +72,18 @@ builder.Services
 // ---------------------------------------
 
 // Messaging
-builder.Services.AddMessagingBus();
+if (useAzureOptimizationDispatch) {
+    builder.Services.AddSingleton<IMessageBus, DisabledLegacyOptimizationMessageBus>();
+} else {
+    builder.Services.AddMessagingBus();
+}
 builder.Services.AddScoped<IRouteEnrichmentService, RouteEnrichmentService>();
 
 // Background consumers / coordinators
 builder.Services.AddHostedService<CoordinatorService>();
-builder.Services.AddHostedService<OptimizeRouteResultConsumer>();
+if (!useAzureOptimizationDispatch) {
+    builder.Services.AddHostedService<OptimizeRouteResultConsumer>();
+}
 
 // Health checks
 builder.Services.AddHealthChecks();
@@ -126,15 +134,32 @@ app.Run();
 // Local helpers
 // ────────────────────────────────────────────────
 static void ValidateRequiredConfiguration(IConfiguration config) {
-    // Updated to reflect the shift to Entra ID
-    var requiredKeys = new[]
+    var requiredKeys = new List<string>
     {
         "ConnectionStrings:PlannerDb",
-        "RabbitMq:Host",
         "AzureAd:Instance",
         "AzureAd:TenantId",
         "AzureAd:ClientId"
     };
+
+    var dispatchMode = config["Optimization:DispatchMode"] ?? "RabbitMq";
+    if (UseAzureServiceBusDispatch(config)) {
+        requiredKeys.Add("ServiceBus:ConnectionString");
+
+        var hasCosmosConnectionString = !string.IsNullOrWhiteSpace(config["Cosmos:ConnectionString"]);
+        var hasCosmosEndpointAndKey =
+            !string.IsNullOrWhiteSpace(config["Cosmos:Endpoint"]) &&
+            !string.IsNullOrWhiteSpace(config["Cosmos:Key"]);
+
+        if (!hasCosmosConnectionString && !hasCosmosEndpointAndKey) {
+            requiredKeys.Add("Cosmos:ConnectionString or Cosmos:Endpoint plus Cosmos:Key");
+        }
+    } else if (string.Equals(dispatchMode, "RabbitMq", StringComparison.OrdinalIgnoreCase)) {
+        requiredKeys.Add("RabbitMq:Host");
+    } else {
+        throw new InvalidOperationException(
+            $"Unsupported Optimization:DispatchMode '{dispatchMode}'. Supported values are RabbitMq and AzureServiceBus.");
+    }
 
     var missing = requiredKeys
         .Where(k => string.IsNullOrWhiteSpace(config[k]))
@@ -142,9 +167,25 @@ static void ValidateRequiredConfiguration(IConfiguration config) {
 
     if (missing.Count != 0) {
         throw new InvalidOperationException(
-            $"Missing required configuration values for Entra ID integration: {string.Join(", ", missing)}"
+            $"Missing required configuration values: {string.Join(", ", missing)}"
         );
     }
 }
 
+static bool UseAzureServiceBusDispatch(IConfiguration config) =>
+    string.Equals(
+        config["Optimization:DispatchMode"],
+        "AzureServiceBus",
+        StringComparison.OrdinalIgnoreCase);
+
 public partial class Program { }
+
+internal sealed class DisabledLegacyOptimizationMessageBus : IMessageBus {
+    public Task PublishAsync<T>(string queueName, T message) =>
+        throw new InvalidOperationException(
+            "RabbitMQ optimization messaging is disabled because Optimization:DispatchMode is AzureServiceBus.");
+
+    public IDisposable Subscribe<T>(string queueName, Func<T, Task> onMessage) =>
+        throw new InvalidOperationException(
+            "RabbitMQ optimization messaging is disabled because Optimization:DispatchMode is AzureServiceBus.");
+}

--- a/src/Planner.API/Services/OptimizationRunSnapshotBuilder.cs
+++ b/src/Planner.API/Services/OptimizationRunSnapshotBuilder.cs
@@ -23,12 +23,16 @@ public sealed class OptimizationRunSnapshotBuilder(
         var jobs = await dataCenter.GetOrFetchAsync(
             CacheKeys.JobsList(tenantId),
             async () => await dataCenter.DbContext.Jobs
+                .AsNoTracking()
+                .Where(j => j.TenantId == tenantId)
                 .Include(j => j.Location)
                 .ToListAsync(ct)) ?? [];
 
         var vehicles = await dataCenter.GetOrFetchAsync(
             CacheKeys.VehiclesList(tenantId),
             async () => await dataCenter.DbContext.Vehicles
+                .AsNoTracking()
+                .Where(v => v.TenantId == tenantId)
                 .Include(v => v.StartDepot)
                     .ThenInclude(d => d!.Location)
                 .Include(v => v.EndDepot)
@@ -114,12 +118,19 @@ public sealed class OptimizationRunSnapshotBuilder(
 
     private async Task EnsureJobsForAllCustomersAsync(Guid tenantId, CancellationToken ct) {
         var jobsWithNoCustomers = await dataCenter.DbContext.Jobs
-            .Where(j => !dataCenter.DbContext.Customers.Any(c => c.CustomerId == j.CustomerId))
+            .Where(j => j.TenantId == tenantId)
+            .Where(j => !dataCenter.DbContext.Customers.Any(c =>
+                c.TenantId == tenantId &&
+                c.CustomerId == j.CustomerId))
             .ToListAsync(ct);
         dataCenter.DbContext.Jobs.RemoveRange(jobsWithNoCustomers);
 
         var customersWithNoJobs = await dataCenter.DbContext.Customers
-            .Where(c => !dataCenter.DbContext.Jobs.Any(j => j.CustomerId == c.CustomerId))
+            .Where(c => c.TenantId == tenantId)
+            .Include(c => c.Location)
+            .Where(c => !dataCenter.DbContext.Jobs.Any(j =>
+                j.TenantId == tenantId &&
+                j.CustomerId == c.CustomerId))
             .ToListAsync(ct);
 
         var newJobs = customersWithNoJobs.Select(c => new Job {

--- a/src/Planner.Optimization.JobWorker/Program.cs
+++ b/src/Planner.Optimization.JobWorker/Program.cs
@@ -9,6 +9,7 @@ using Planner.Optimization.JobWorker;
 var builder = Host.CreateApplicationBuilder(args);
 builder.Configuration.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
 builder.Configuration.AddEnvironmentVariables();
+ValidateRequiredConfiguration(builder.Configuration);
 
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole();
@@ -21,3 +22,28 @@ using var host = builder.Build();
 var processor = host.Services.GetRequiredService<OptimizationJobProcessor>();
 var exitCode = await processor.ProcessOneAsync(CancellationToken.None);
 Environment.ExitCode = exitCode;
+
+static void ValidateRequiredConfiguration(IConfiguration config) {
+    var requiredKeys = new List<string>
+    {
+        "ServiceBus:ConnectionString"
+    };
+
+    var hasCosmosConnectionString = !string.IsNullOrWhiteSpace(config["Cosmos:ConnectionString"]);
+    var hasCosmosEndpointAndKey =
+        !string.IsNullOrWhiteSpace(config["Cosmos:Endpoint"]) &&
+        !string.IsNullOrWhiteSpace(config["Cosmos:Key"]);
+
+    if (!hasCosmosConnectionString && !hasCosmosEndpointAndKey) {
+        requiredKeys.Add("Cosmos:ConnectionString or Cosmos:Endpoint plus Cosmos:Key");
+    }
+
+    var missing = requiredKeys
+        .Where(k => string.IsNullOrWhiteSpace(config[k]))
+        .ToList();
+
+    if (missing.Count != 0) {
+        throw new InvalidOperationException(
+            $"Missing required optimization job worker configuration values: {string.Join(", ", missing)}");
+    }
+}

--- a/test/Planner.API.EndToEndTests/OptimizationController.EndToEndTests.cs
+++ b/test/Planner.API.EndToEndTests/OptimizationController.EndToEndTests.cs
@@ -8,6 +8,8 @@ using Planner.Messaging.Messaging;
 using Planner.Messaging.Optimization.Inputs;
 using Planner.Testing;
 using Planner.Application.OptimizationRuns;
+using Planner.Domain;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -80,5 +82,100 @@ public sealed class OptimizationControllerEndToEndTests {
         queue.Messages[0].TenantId.Should().Be(tenant.TenantId);
         queue.Messages[0].OptimizationRunId.Should().Be(store.Runs.Single().Key);
         bus!.PublishedMessages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Solve_endpoint_in_azure_mode_snapshots_current_tenant_only() {
+        using var factory = new TestApiFactory(dispatchMode: "AzureServiceBus");
+
+        var tenant = factory.Get<ITenantContext>();
+        var db = factory.Get<PlannerDbContext>();
+        var controller = factory.Get<OptimizationController>();
+        controller.MockUserContext();
+
+        DomainSeed.SeedSmallScenario(db, tenant.TenantId);
+        SeedOtherTenantSmallScenario(
+            db,
+            Guid.Parse("00000000-0000-0000-0000-000000000002"));
+        await db.SaveChangesAsync();
+
+        var result = await controller.Solve();
+
+        result.Should().BeOfType<OkObjectResult>();
+
+        var store = (TestApiFactory.InMemoryOptimizationRunStore)factory.Get<IOptimizationRunStore>();
+        var run = store.Runs.Values.Single();
+
+        run.TenantId.Should().Be(tenant.TenantId);
+        run.RequestSnapshot.TenantId.Should().Be(tenant.TenantId);
+        run.RequestSnapshot.Vehicles.Should().ContainSingle(v => v.VehicleId == 1);
+        run.RequestSnapshot.Stops.Select(s => s.LocationId).Should().BeEquivalentTo([1L, 2L]);
+    }
+
+    private static void SeedOtherTenantSmallScenario(PlannerDbContext db, Guid tenantId) {
+        var depotLocation = new Location {
+            Id = 101,
+            Address = "Other Tenant Depot",
+            Latitude = -32.95,
+            Longitude = 116.86
+        };
+
+        var depot = new Depot {
+            Id = 101,
+            TenantId = tenantId,
+            Location = depotLocation,
+            Name = "Other Hub"
+        };
+
+        var vehicle = new Vehicle {
+            Id = 101,
+            TenantId = tenantId,
+            Name = "Other Truck",
+            StartDepot = depot,
+            EndDepot = depot,
+            MaxPallets = 10,
+            MaxWeight = 1000,
+            ShiftLimitMinutes = 480,
+            DriverRatePerHour = 50,
+            MaintenanceRatePerHour = 10,
+            FuelRatePerKm = 1.5,
+            BaseFee = 20,
+            SpeedFactor = 1.0
+        };
+
+        var customerLocation = new Location {
+            Id = 102,
+            Address = "Other Tenant Customer",
+            Latitude = -32.96,
+            Longitude = 116.87
+        };
+
+        var customer = new Customer {
+            CustomerId = 101,
+            TenantId = tenantId,
+            Name = "Other Customer",
+            Location = customerLocation,
+            DefaultServiceMinutes = 15
+        };
+
+        var job = new Job {
+            Id = 101,
+            TenantId = tenantId,
+            CustomerId = customer.CustomerId,
+            Name = "Other Delivery",
+            Location = customerLocation,
+            JobType = JobType.Delivery,
+            ServiceTimeMinutes = 15,
+            ReadyTime = 0,
+            DueTime = 1440,
+            PalletDemand = 2,
+            WeightDemand = 200
+        };
+
+        db.Locations.AddRange(depotLocation, customerLocation);
+        db.Depots.Add(depot);
+        db.Customers.Add(customer);
+        db.Vehicles.Add(vehicle);
+        db.Jobs.Add(job);
     }
 }


### PR DESCRIPTION
## What changed

- Gates API optimization dispatch on `Optimization:DispatchMode`, keeping RabbitMQ active for legacy mode and disabling the legacy result consumer in Azure Service Bus mode.
- Adds fail-fast Service Bus/Cosmos configuration validation for the one-message optimization job worker.
- Tenant-scopes SQL reads used to build optimization snapshots before they are stored in Cosmos.
- Adds end-to-end coverage that Azure dispatch stores a tenant-safe Cosmos run snapshot and enqueues only the lightweight optimization job message.

## Why

The Azure-native optimization path depends on Cosmos DB as the run lifecycle source of truth and Service Bus as a lightweight command queue. The API should not require RabbitMQ in that mode, and the worker should process the Cosmos request snapshot directly from the Service Bus run identifier.

## Validation

- `dotnet build`
- `dotnet test`