### PR TITLE
[codex] Authenticate and scope users endpoint

### DIFF
--- a/src/Planner.API/Controllers/UsersController.cs
+++ b/src/Planner.API/Controllers/UsersController.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Planner.Application.Features.Users;
 using System.Diagnostics;
@@ -6,6 +7,7 @@ using System.Diagnostics;
 namespace Planner.API.Controllers;
 
 [ApiController]
+[Authorize]
 [Route("api/[controller]")]
 public class UsersController(IMediator mediator, ILogger<UsersController> logger) : ControllerBase {
     [HttpGet]

--- a/src/Planner.Application/Caching/CacheKeys.cs
+++ b/src/Planner.Application/Caching/CacheKeys.cs
@@ -5,7 +5,7 @@ public static class CacheKeys {
 
     public static string ConfigInit(Guid tenantId) => $"config:init:{Scope(tenantId)}";
     public static string TenantMetadata(Guid tenantId) => $"tenants:metadata:{Scope(tenantId)}";
-    public static string UsersList() => "users:list:scope:all";
+    public static string UsersList(Guid? tenantId = null) => $"users:list:{Scope(tenantId)}";
 
     public static string JobsList(Guid? tenantId = null) => $"jobs:list:{Scope(tenantId)}";
     public static string JobById(long id, Guid? tenantId = null) => $"jobs:item:{Scope(tenantId)}:{id}";

--- a/src/Planner.Application/Features/Users/UserRequests.cs
+++ b/src/Planner.Application/Features/Users/UserRequests.cs
@@ -10,15 +10,16 @@ public sealed record UserSummary(string Email, string Role, DateTime CreatedAt);
 
 public sealed record GetUsersQuery : IRequest<List<UserSummary>>;
 
-public sealed class UserQueryHandler(IPlannerDataCenter dataCenter) :
+public sealed class UserQueryHandler(IPlannerDataCenter dataCenter, ITenantContext tenant) :
     IRequestHandler<GetUsersQuery, List<UserSummary>> {
     public async Task<List<UserSummary>> Handle(
         GetUsersQuery query,
         CancellationToken cancellationToken) =>
         await dataCenter.GetOrFetchAsync(
-            CacheKeys.UsersList(),
+            CacheKeys.UsersList(tenant.TenantId),
             async () => await dataCenter.DbContext.Users
                 .AsNoTracking()
+                .Where(u => u.TenantId == tenant.TenantId)
                 .Select(u => new UserSummary(u.Email, u.Role, u.CreatedAt))
                 .ToListAsync(cancellationToken),
             cancellationToken: cancellationToken) ?? [];

--- a/test/Planner.API.EndToEndTests/Tests/UsersController.EndToEndTests.cs
+++ b/test/Planner.API.EndToEndTests/Tests/UsersController.EndToEndTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Planner.API.Controllers;
+using Planner.API.EndToEndTests.Fixtures;
+using Planner.Application;
+using Planner.Application.Features.Users;
+using Planner.Domain;
+using Planner.Infrastructure.Persistence;
+using Planner.Testing;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Planner.API.EndToEndTests.Tests;
+
+public sealed class UsersControllerEndToEndTests {
+    [Fact]
+    public void UsersController_requires_authorization() {
+        typeof(UsersController)
+            .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true)
+            .Should()
+            .NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetUsers_returns_only_current_tenant_users() {
+        using var factory = new TestApiFactory();
+        var tenant = factory.Get<ITenantContext>();
+        var db = factory.Get<PlannerDbContext>();
+
+        db.Users.AddRange(
+            new User {
+                TenantId = tenant.TenantId,
+                Email = "current@example.com",
+                Role = "Admin"
+            },
+            new User {
+                TenantId = Guid.NewGuid(),
+                Email = "other@example.com",
+                Role = "Admin"
+            });
+        await db.SaveChangesAsync();
+
+        var controller = new UsersController(
+            factory.Get<IMediator>(),
+            factory.Get<ILogger<UsersController>>());
+        controller.MockUserContext();
+
+        var result = await controller.GetUsers(CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var data = ok.Value!
+            .GetType()
+            .GetProperty("Data")!
+            .GetValue(ok.Value)
+            .Should()
+            .BeAssignableTo<List<UserSummary>>()
+            .Subject;
+
+        data.Should().ContainSingle();
+        data[0].Email.Should().Be("current@example.com");
+    }
+}


### PR DESCRIPTION
## Summary

- Require authorization on `UsersController`.
- Scope `GetUsersQuery` to the current `ITenantContext.TenantId`.
- Make the users list cache key tenant-aware.
- Add end-to-end style coverage for authorization metadata and tenant filtering.

## Why

The previous `/api/users` endpoint was outside the authenticated controller pattern and returned a globally cached user list. In a multi-tenant system, user enumeration must be restricted to authenticated callers and filtered by tenant.

## Validation

- `dotnet build -m:1 -p:BaseOutputPath=<temp>\build\`
- `dotnet test --no-build -p:BaseOutputPath=<temp>\build\`

Both passed. Existing nullable/obsolete warnings remain unrelated to this change.