### PR TITLE
[codex] Fix GraphQL authorization gaps

### DIFF
--- a/src/Planner.API/GraphQL/Mutation.cs
+++ b/src/Planner.API/GraphQL/Mutation.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using HotChocolate.Authorization;
 using Planner.Application.CQRS;
 using Planner.Application.Features.Customers;
 using Planner.Application.Features.Depots;
@@ -11,6 +12,7 @@ using Planner.Domain;
 
 namespace Planner.API.GraphQL;
 
+[Authorize]
 public sealed class Mutation {
     public async Task<JobDto> CreateJob(
         JobDto input,

--- a/src/Planner.API/GraphQL/Query.cs
+++ b/src/Planner.API/GraphQL/Query.cs
@@ -69,11 +69,13 @@ public sealed class Query {
         CancellationToken cancellationToken) =>
         mediator.Send(new GetDepotByIdQuery(id), cancellationToken);
 
+    [Authorize]
     public Task<List<LocationDto>> GetLocations(
         [Service] IMediator mediator,
         CancellationToken cancellationToken) =>
         mediator.Send(new GetLocationsQuery(), cancellationToken);
 
+    [Authorize]
     public Task<LocationDto?> GetLocationById(
         long id,
         [Service] IMediator mediator,
@@ -93,11 +95,13 @@ public sealed class Query {
         CancellationToken cancellationToken) =>
         mediator.Send(new GetRouteByIdQuery(id), cancellationToken);
 
+    [Authorize]
     public Task<List<TaskItem>> GetTasks(
         [Service] IMediator mediator,
         CancellationToken cancellationToken) =>
         mediator.Send(new GetTasksQuery(), cancellationToken);
 
+    [Authorize]
     public Task<TaskItem?> GetTaskById(
         long id,
         [Service] IMediator mediator,

--- a/src/Planner.API/Program.cs
+++ b/src/Planner.API/Program.cs
@@ -126,7 +126,7 @@ app.UseMiddleware<TenantContextMiddleware>();
 
 app.MapControllers();
 app.MapHealthChecks("/health", new HealthCheckOptions { Predicate = _ => true });
-app.MapGraphQL("/graphql");
+app.MapGraphQL("/graphql").RequireAuthorization();
 
 app.Run();
 

--- a/test/Planner.API.Tests/GraphQLAuthorizationTests.cs
+++ b/test/Planner.API.Tests/GraphQLAuthorizationTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using HotChocolateAuthorizeAttribute = HotChocolate.Authorization.AuthorizeAttribute;
+using Planner.API.GraphQL;
+
+namespace Planner.API.Tests;
+
+public sealed class GraphQLAuthorizationTests {
+    [Fact]
+    public void All_query_resolvers_require_authorization() {
+        var publicResolvers = typeof(Query)
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+            .Where(m => !m.IsSpecialName);
+
+        publicResolvers.Should()
+            .OnlyContain(method => HasAuthorizeAttribute(method));
+    }
+
+    [Fact]
+    public void Mutation_type_requires_authorization() {
+        typeof(Mutation)
+            .GetCustomAttributes(typeof(HotChocolateAuthorizeAttribute), inherit: true)
+            .Should()
+            .NotBeEmpty();
+    }
+
+    private static bool HasAuthorizeAttribute(MethodInfo method) =>
+        method.GetCustomAttributes(typeof(HotChocolateAuthorizeAttribute), inherit: true).Any();
+}


### PR DESCRIPTION
Closes #82

## Summary

- Require ASP.NET Core authorization on the `/graphql` endpoint.
- Add HotChocolate `[Authorize]` protection to location and task query resolvers.
- Protect all GraphQL mutations with mutation type-level authorization.
- Add regression tests to catch unprotected public query resolvers and missing mutation type authorization.

## Architecture notes

This keeps Planner.Api as the authenticated command/query control plane and does not change tenant data access behavior. The change is limited to GraphQL endpoint and resolver authorization.

## Test results

- `dotnet build` passed.
- `dotnet test` passed.

## Risks / follow-up

No known follow-up. `AGENTS.md` has a separate local uncommitted edit and was intentionally excluded from this PR.