### PR TITLE
[codex] Fix RabbitMQ URI configuration

### DIFF
--- a/Planner.sln
+++ b/Planner.sln
@@ -60,6 +60,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Planner.Orchestration.Tests
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Planner.Infrastructure.Tests", "test\Planner.Infrastructure.Tests\Planner.Infrastructure.Tests.csproj", "{5A3B0D6B-8042-4EF8-9F5C-ACE53D21510E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Planner.Optimization.Worker.Tests", "test\Planner.Optimization.Worker.Tests\Planner.Optimization.Worker.Tests.csproj", "{DE96FAA8-01A3-49FF-B1FA-9B7FC407D4B1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -310,6 +312,18 @@ Global
 		{5A3B0D6B-8042-4EF8-9F5C-ACE53D21510E}.Release|x64.Build.0 = Release|Any CPU
 		{5A3B0D6B-8042-4EF8-9F5C-ACE53D21510E}.Release|x86.ActiveCfg = Release|Any CPU
 		{5A3B0D6B-8042-4EF8-9F5C-ACE53D21510E}.Release|x86.Build.0 = Release|Any CPU
+		{DE96FAA8-01A3-49FF-B1FA-9B7FC407D4B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE96FAA8-01A3-49FF-B1FA-9B7FC407D4B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE96FAA8-01A3-49FF-B1FA-9B7FC407D4B1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DE96FAA8-01A3-49FF-B1FA-9B7FC407D4B1}.Debug|x64.Build.0 = Debug|Any CPU
+		{DE96FAA8-01A3-49FF-B1FA-9B7FC407D4B1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DE96FAA8-01A3-49FF-B1FA-9B7FC407D4B1}.Debug|x86.Build.0 = Debug|Any CPU
+		{DE96FAA8-01A3-49FF-B1FA-9B7FC407D4B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE96FAA8-01A3-49FF-B1FA-9B7FC407D4B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE96FAA8-01A3-49FF-B1FA-9B7FC407D4B1}.Release|x64.ActiveCfg = Release|Any CPU
+		{DE96FAA8-01A3-49FF-B1FA-9B7FC407D4B1}.Release|x64.Build.0 = Release|Any CPU
+		{DE96FAA8-01A3-49FF-B1FA-9B7FC407D4B1}.Release|x86.ActiveCfg = Release|Any CPU
+		{DE96FAA8-01A3-49FF-B1FA-9B7FC407D4B1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -335,6 +349,7 @@ Global
 		{B8C85820-D20C-42AD-9C5D-A30514E4A1D4} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{6AFECBA6-84E7-49A0-A447-4DD5F322C3D5} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{5A3B0D6B-8042-4EF8-9F5C-ACE53D21510E} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{DE96FAA8-01A3-49FF-B1FA-9B7FC407D4B1} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {742FA71F-FF0D-4401-908C-0ED50B8BEB6B}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
         condition: service_healthy
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - ASPNETCORE_URLS=http://+:5000;http://+:7085 
+      - ASPNETCORE_URLS=http://+:5000;http://+:7085
       - Optimization__DispatchMode=${OPTIMIZATION_DISPATCH_MODE:-RabbitMq}
       - ConnectionStrings__PlannerDb=Server=sqlserver,1433;Database=PlannerDB;User Id=sa;Password=PlannerDevPass123;Encrypt=False;TrustServerCertificate=True;
       - SignalR__Server=http://planner-api:7085
@@ -55,10 +55,10 @@ services:
       - SignalR__Route=/hubs/planner
       - Cors__AllowedOrigins__0=https://localhost:7014
       - Cors__AllowedOrigins__1=http://localhost:5212
-      - RabbitMq__Host=rabbitmq
-      - RabbitMq__User=planner
-      - RabbitMq__Pass=planner
-      - RabbitMq__Port=5672
+      - RabbitMq__Host=${RABBITMQ_HOST:-rabbitmq}
+      - RabbitMq__User=${RABBITMQ_USERNAME:-planner}
+      - RabbitMq__Pass=${RABBITMQ_PASSWORD:-planner}
+      - RabbitMq__Port=${RABBITMQ_PORT:-5672}
       - AzureAd__Instance=https://login.microsoftonline.com/
       - AzureAd__TenantId=common
       - AzureAd__ClientId=8621f365-5e51-4b25-931a-1c717ead22ac

--- a/src/Planner.Messaging/Properties/AssemblyInfo.cs
+++ b/src/Planner.Messaging/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Planner.Optimization.Worker.Tests")]

--- a/src/Planner.Messaging/RabbitMQ/RabbitMqConnection.cs
+++ b/src/Planner.Messaging/RabbitMQ/RabbitMqConnection.cs
@@ -11,6 +11,7 @@ public interface IRabbitMqConnection : IDisposable {
 
 internal sealed class RabbitMqConnection : IRabbitMqConnection {
     private readonly ConnectionFactory _factory;
+    private readonly string _configuredEndpoint;
     private IConnection? _connection;
     private readonly object _lock = new();
     private readonly ILogger<RabbitMqConnection> _logger;
@@ -20,18 +21,14 @@ internal sealed class RabbitMqConnection : IRabbitMqConnection {
         ILogger<RabbitMqConnection> logger) {
         _logger = logger;
 
-        _factory = new ConnectionFactory {
-            HostName = configuration["RabbitMq:Host"] ?? "localhost",
-            UserName = configuration["RabbitMq:User"] ?? "guest",
-            Password = configuration["RabbitMq:Pass"] ?? "guest",
-            Port = int.TryParse(configuration["RabbitMq:Port"], out var p) ? p : 5672,
-            DispatchConsumersAsync = true
-        };
+        var settings = RabbitMqConnectionSettings.FromConfiguration(configuration);
+        _factory = new ConnectionFactory();
+        settings.ApplyTo(_factory);
+        _configuredEndpoint = settings.EndpointForLog;
 
         _logger.LogInformation(
-            "RabbitMQ configured for host {Host}:{Port}",
-            _factory.HostName,
-            _factory.Port
+            "RabbitMQ configured for endpoint {Endpoint}",
+            _configuredEndpoint
         );
     }
 
@@ -54,11 +51,11 @@ internal sealed class RabbitMqConnection : IRabbitMqConnection {
                 RegisterEventHandlers(_connection);
 
                 _logger.LogInformation(
-                    "RabbitMQ connection established to {Host}",
-                    _connection.Endpoint.HostName
+                    "RabbitMQ connection established to {Endpoint}",
+                    $"{_connection.Endpoint.HostName}:{_connection.Endpoint.Port}"
                 );
             } catch (Exception ex) {
-                _logger.LogError(ex, "RabbitMQ connection failed");
+                _logger.LogError(ex, "RabbitMQ connection failed for endpoint {Endpoint}", _configuredEndpoint);
                 throw; // fail fast, caller decides retry
             }
         }

--- a/src/Planner.Messaging/RabbitMQ/RabbitMqConnectionSettings.cs
+++ b/src/Planner.Messaging/RabbitMQ/RabbitMqConnectionSettings.cs
@@ -1,0 +1,123 @@
+using Microsoft.Extensions.Configuration;
+using RabbitMQ.Client;
+
+namespace Planner.Messaging.RabbitMQ;
+
+internal sealed class RabbitMqConnectionSettings {
+    private const int DefaultPort = 5672;
+    private const int DefaultSslPort = 5671;
+    private readonly Uri? _uri;
+    private readonly string? _hostName;
+    private readonly string? _userName;
+    private readonly string? _password;
+    private readonly int _port;
+
+    private RabbitMqConnectionSettings(Uri uri) {
+        _uri = uri;
+        EndpointForLog = FormatUriForLog(uri);
+    }
+
+    private RabbitMqConnectionSettings(string hostName, string userName, string password, int port) {
+        _hostName = hostName;
+        _userName = userName;
+        _password = password;
+        _port = port;
+        EndpointForLog = $"{hostName}:{port}";
+    }
+
+    public string EndpointForLog { get; }
+
+    public static RabbitMqConnectionSettings FromConfiguration(IConfiguration configuration) {
+        var configuredUri = FirstNonWhiteSpace(
+            configuration["RabbitMq:Uri"],
+            configuration["RabbitMq:ConnectionString"]);
+        var configuredHost = configuration["RabbitMq:Host"];
+        var endpointValue = FirstNonWhiteSpace(configuredUri, configuredHost) ?? "localhost";
+
+        if (TryCreateAmqpUri(endpointValue, out var uri)) {
+            return new RabbitMqConnectionSettings(ApplyCredentialOverrides(uri, configuration));
+        }
+
+        if (LooksLikeUri(endpointValue)) {
+            throw new InvalidOperationException(
+                "RabbitMq connection configuration must be a host name or a valid amqp:// or amqps:// URI.");
+        }
+
+        var userName = FirstNonWhiteSpace(configuration["RabbitMq:User"]) ?? "guest";
+        var password = FirstNonWhiteSpace(configuration["RabbitMq:Pass"]) ?? "guest";
+        var port = GetConfiguredPort(configuration, DefaultPort);
+
+        return new RabbitMqConnectionSettings(endpointValue, userName, password, port);
+    }
+
+    public void ApplyTo(ConnectionFactory factory) {
+        if (_uri is not null) {
+            factory.Uri = _uri;
+        } else {
+            factory.HostName = _hostName!;
+            factory.UserName = _userName!;
+            factory.Password = _password!;
+            factory.Port = _port;
+        }
+
+        factory.DispatchConsumersAsync = true;
+    }
+
+    private static Uri ApplyCredentialOverrides(Uri uri, IConfiguration configuration) {
+        if (!string.IsNullOrEmpty(uri.UserInfo)) {
+            return uri;
+        }
+
+        var configuredUserName = FirstNonWhiteSpace(configuration["RabbitMq:User"]);
+        var configuredPassword = FirstNonWhiteSpace(configuration["RabbitMq:Pass"]);
+        if (configuredUserName is null && configuredPassword is null) {
+            return uri;
+        }
+
+        var builder = new UriBuilder(uri);
+        if (configuredUserName is not null) {
+            builder.UserName = configuredUserName;
+        }
+
+        if (configuredPassword is not null) {
+            builder.Password = configuredPassword;
+        }
+
+        return builder.Uri;
+    }
+
+    private static bool TryCreateAmqpUri(string value, out Uri uri) {
+        if (Uri.TryCreate(value, UriKind.Absolute, out uri!)
+            && (string.Equals(uri.Scheme, "amqp", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(uri.Scheme, "amqps", StringComparison.OrdinalIgnoreCase))) {
+            return true;
+        }
+
+        uri = null!;
+        return false;
+    }
+
+    private static bool LooksLikeUri(string value) =>
+        value.Contains("://", StringComparison.Ordinal);
+
+    private static int GetConfiguredPort(IConfiguration configuration, int defaultPort) =>
+        int.TryParse(configuration["RabbitMq:Port"], out var port) && port > 0
+            ? port
+            : defaultPort;
+
+    private static string FormatUriForLog(Uri uri) {
+        var port = uri.Port > 0
+            ? uri.Port
+            : string.Equals(uri.Scheme, "amqps", StringComparison.OrdinalIgnoreCase)
+                ? DefaultSslPort
+                : DefaultPort;
+        var path = string.Equals(uri.AbsolutePath, "/", StringComparison.Ordinal)
+            ? string.Empty
+            : uri.AbsolutePath;
+
+        return $"{uri.Scheme}://{uri.Host}:{port}{path}";
+    }
+
+    private static string? FirstNonWhiteSpace(params string?[] values) =>
+        values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))?.Trim();
+}

--- a/test/Planner.Optimization.Worker.Tests/Planner.Optimization.Worker.Tests.csproj
+++ b/test/Planner.Optimization.Worker.Tests/Planner.Optimization.Worker.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Planner.Messaging\Planner.Messaging.csproj" />
     <ProjectReference Include="..\..\src\Planner.Optimization.Worker\Planner.Optimization.Worker.csproj" />
   </ItemGroup>
 

--- a/test/Planner.Optimization.Worker.Tests/RabbitMqConnectionSettingsTests.cs
+++ b/test/Planner.Optimization.Worker.Tests/RabbitMqConnectionSettingsTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Planner.Messaging.RabbitMQ;
+using RabbitMQ.Client;
+
+namespace Planner.Optimization.Worker.Tests;
+
+public sealed class RabbitMqConnectionSettingsTests {
+    [Fact]
+    public void FromConfiguration_UsesPlainHostSettings() {
+        var settings = RabbitMqConnectionSettings.FromConfiguration(Configuration([
+            Setting("RabbitMq:Host", "rabbitmq"),
+            Setting("RabbitMq:User", "planner"),
+            Setting("RabbitMq:Pass", "planner-pass"),
+            Setting("RabbitMq:Port", "5673")
+        ]));
+
+        var factory = new ConnectionFactory();
+        settings.ApplyTo(factory);
+
+        factory.HostName.Should().Be("rabbitmq");
+        factory.UserName.Should().Be("planner");
+        factory.Password.Should().Be("planner-pass");
+        factory.Port.Should().Be(5673);
+        factory.DispatchConsumersAsync.Should().BeTrue();
+        settings.EndpointForLog.Should().Be("rabbitmq:5673");
+    }
+
+    [Fact]
+    public void FromConfiguration_UsesUriSettingsWithoutLoggingCredentials() {
+        var uriWithCredentials = new UriBuilder("amqps", "fly.rmq.cloudamqp.com") {
+            UserName = "user-name",
+            Password = "uri-pass",
+            Path = "vhost-name"
+        }.Uri.ToString();
+
+        var settings = RabbitMqConnectionSettings.FromConfiguration(Configuration([
+            Setting("RabbitMq:Host", uriWithCredentials),
+            Setting("RabbitMq:Port", "5672")
+        ]));
+
+        var factory = new ConnectionFactory();
+        settings.ApplyTo(factory);
+
+        factory.HostName.Should().Be("fly.rmq.cloudamqp.com");
+        factory.UserName.Should().Be("user-name");
+        factory.Password.Should().Be("uri-pass");
+        factory.VirtualHost.Should().Be("vhost-name");
+        factory.Port.Should().Be(5671);
+        factory.Ssl.Enabled.Should().BeTrue();
+        factory.DispatchConsumersAsync.Should().BeTrue();
+        settings.EndpointForLog.Should().Be("amqps://fly.rmq.cloudamqp.com:5671/vhost-name");
+        settings.EndpointForLog.Should().NotContain("user-name");
+        settings.EndpointForLog.Should().NotContain("uri-pass");
+    }
+
+    [Fact]
+    public void FromConfiguration_AppliesSeparateCredentialsToUriWithoutUserInfo() {
+        var settings = RabbitMqConnectionSettings.FromConfiguration(Configuration([
+            Setting("RabbitMq:Host", "amqp://broker.example.com/my-vhost"),
+            Setting("RabbitMq:User", "configured-user"),
+            Setting("RabbitMq:Pass", "configured-password")
+        ]));
+
+        var factory = new ConnectionFactory();
+        settings.ApplyTo(factory);
+
+        factory.HostName.Should().Be("broker.example.com");
+        factory.UserName.Should().Be("configured-user");
+        factory.Password.Should().Be("configured-password");
+        factory.VirtualHost.Should().Be("my-vhost");
+        settings.EndpointForLog.Should().Be("amqp://broker.example.com:5672/my-vhost");
+    }
+
+    [Fact]
+    public void FromConfiguration_RejectsInvalidUriStyleHost() {
+        var act = () => RabbitMqConnectionSettings.FromConfiguration(Configuration([
+            Setting("RabbitMq:Host", "https://broker.example.com")
+        ]));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("RabbitMq connection configuration must be a host name or a valid amqp:// or amqps:// URI.");
+    }
+
+    private static IConfiguration Configuration(IEnumerable<KeyValuePair<string, string?>> values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+    private static KeyValuePair<string, string?> Setting(string key, string value) =>
+        new(key, value);
+}


### PR DESCRIPTION
Closes #85.

## Summary

- Adds RabbitMQ connection settings parsing for plain hosts and `amqp://` / `amqps://` URIs.
- Sanitizes RabbitMQ endpoint logging so credentials are not emitted.
- Keeps docker-compose pointed at the local `rabbitmq` service by default while preserving environment overrides.
- Adds focused worker tests and includes the worker test project in the root solution.

## Root cause

The RabbitMQ adapter treated `RabbitMq:Host` as a DNS host name in all cases. When a CloudAMQP-style URI was provided, the entire URI-like value was passed as the host name, causing DNS resolution failure and logging credential-bearing configuration values.

## Validation

- `dotnet build` passed.
- `dotnet test` passed.

Build produced existing warnings in Firestore credential/nullability and TenantContext nullability code that are outside this change.