### PR TITLE
[codex] add Azure optimization dispatch path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://+:5000;http://+:7085
       - Optimization__DispatchMode=${OPTIMIZATION_DISPATCH_MODE:-RabbitMq}
+      - OptimizationMessaging__Transport=${OPTIMIZATION_MESSAGING_TRANSPORT:-RabbitMQ}
+      - Optimization__WorkerResultApiKey=${OPTIMIZATION_WORKER_RESULT_API_KEY:-planner-dev-worker-result-key}
       - ConnectionStrings__PlannerDb=Server=sqlserver,1433;Database=PlannerDB;User Id=sa;Password=PlannerDevPass123;Encrypt=False;TrustServerCertificate=True;
       - SignalR__Server=http://planner-api:7085
       - SignalR__Client=http://localhost:7014
@@ -142,10 +144,22 @@ services:
         condition: service_started
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+      - Optimization__DispatchMode=${OPTIMIZATION_DISPATCH_MODE:-RabbitMq}
+      - OptimizationMessaging__Transport=${OPTIMIZATION_MESSAGING_TRANSPORT:-RabbitMQ}
       - RabbitMq__Host=rabbitmq
       - RabbitMq__User=planner
       - RabbitMq__Pass=planner
       - RabbitMq__Port=5672
+      - Cosmos__ConnectionString=AccountEndpoint=https://cosmosdb:8081/;AccountKey=${COSMOS_EMULATOR_KEY:-cGxhbm5lci1sb2NhbC1jb3Ntb3MtZW11bGF0b3ItZGV2ZWxvcG1lbnQta2V5LTAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==};DisableServerCertificateValidation=True;
+      - Cosmos__DatabaseName=planner
+      - Cosmos__OptimizationRunsContainerName=optimizationRuns
+      - Cosmos__ConnectionMode=Gateway
+      - Cosmos__RequestTimeoutSeconds=15
+      - Cosmos__DisableServerCertificateValidation=${COSMOS_DISABLE_SERVER_CERTIFICATE_VALIDATION:-true}
+      - ServiceBus__ConnectionString=Endpoint=sb://servicebus-emulator;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
+      - ServiceBus__OptimizationQueueName=optimization-jobs
+      - PlannerApi__BaseUrl=http://planner-api:5000
+      - Optimization__WorkerResultApiKey=${OPTIMIZATION_WORKER_RESULT_API_KEY:-planner-dev-worker-result-key}
       - SignalR__Server=http://planner-api:7085
       - SignalR__Client=http://localhost:7014
       - SignalR__Route=/hubs/planner

--- a/src/Planner.API/Controllers/OptimizationController.cs
+++ b/src/Planner.API/Controllers/OptimizationController.cs
@@ -6,13 +6,18 @@ using Planner.Application.Features.Optimization;
 using Planner.Contracts.Optimization;
 using Planner.Contracts.OptimizationRuns;
 using Planner.Messaging.Optimization.Inputs;
+using Planner.Messaging.Optimization.Outputs;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Planner.API.Controllers;
 
 [ApiController]
 [Route("api/vrp")]
 [Authorize]
-public class OptimizationController(IMediator mediator) : PlannerControllerBase {
+public class OptimizationController(
+    IMediator mediator,
+    IConfiguration configuration) : PlannerControllerBase {
     /// <summary>
     /// Accept a route optimization request and dispatch it to the optimization worker.
     /// </summary>
@@ -72,8 +77,46 @@ public class OptimizationController(IMediator mediator) : PlannerControllerBase 
         };
     }
 
+    [HttpPost("runs/{optimizationRunId:guid}/result")]
+    [AllowAnonymous]
+    public async Task<IActionResult> CompleteRun(
+        Guid optimizationRunId,
+        [FromBody] OptimizeRouteResponse response,
+        CancellationToken cancellationToken) {
+        if (!IsAuthorizedWorkerRequest()) {
+            return StatusCode(StatusCodes.Status403Forbidden);
+        }
+
+        if (response.OptimizationRunId != optimizationRunId) {
+            return BadRequest("Route optimizationRunId does not match the response body.");
+        }
+
+        var result = await mediator.Send(
+            new CompleteOptimizationRunCommand(response),
+            cancellationToken);
+
+        return NoContentOrError(result);
+    }
+
     private Task<OptimizeRouteRequest> BuildRequestFromDomainAsync(int? searchTimeLimitSeconds = null) =>
         mediator.Send(
             new BuildOptimizationRequestQuery(searchTimeLimitSeconds),
             HttpContext?.RequestAborted ?? CancellationToken.None);
+
+    private bool IsAuthorizedWorkerRequest() {
+        var expectedApiKey = configuration["Optimization:WorkerResultApiKey"];
+        if (string.IsNullOrWhiteSpace(expectedApiKey)) {
+            return false;
+        }
+
+        if (!Request.Headers.TryGetValue("X-Optimization-Worker-Key", out var providedApiKey)) {
+            return false;
+        }
+
+        var expectedBytes = Encoding.UTF8.GetBytes(expectedApiKey);
+        var providedBytes = Encoding.UTF8.GetBytes(providedApiKey.ToString());
+
+        return expectedBytes.Length == providedBytes.Length
+            && CryptographicOperations.FixedTimeEquals(expectedBytes, providedBytes);
+    }
 }

--- a/src/Planner.API/Program.cs
+++ b/src/Planner.API/Program.cs
@@ -12,7 +12,6 @@ using Planner.Application.OptimizationRuns;
 using Planner.Infrastructure;
 using Planner.Infrastructure.Coordinator;
 using Planner.Messaging;
-using Planner.Messaging.Messaging;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -116,7 +115,7 @@ builder.Services
 
 // Messaging
 if (useAzureOptimizationDispatch) {
-    builder.Services.AddSingleton<IMessageBus, DisabledLegacyOptimizationMessageBus>();
+    builder.Services.AddAzureOptimizationMessaging();
 } else {
     builder.Services.AddMessagingBus();
 }
@@ -187,9 +186,10 @@ static void ValidateRequiredConfiguration(IConfiguration config) {
         "AzureAd:ClientId"
     };
 
-    var dispatchMode = config["Optimization:DispatchMode"] ?? "RabbitMq";
+    var dispatchMode = OptimizationDispatchMode(config);
     if (UseAzureServiceBusDispatch(config)) {
         requiredKeys.Add("ServiceBus:ConnectionString");
+        requiredKeys.Add("Optimization:WorkerResultApiKey");
 
         var hasCosmosConnectionString = !string.IsNullOrWhiteSpace(config["Cosmos:ConnectionString"]);
         var hasCosmosEndpointAndKey =
@@ -199,11 +199,11 @@ static void ValidateRequiredConfiguration(IConfiguration config) {
         if (!hasCosmosConnectionString && !hasCosmosEndpointAndKey) {
             requiredKeys.Add("Cosmos:ConnectionString or Cosmos:Endpoint plus Cosmos:Key");
         }
-    } else if (string.Equals(dispatchMode, "RabbitMq", StringComparison.OrdinalIgnoreCase)) {
+    } else if (IsRabbitMqDispatch(dispatchMode)) {
         requiredKeys.Add("RabbitMq:Host");
     } else {
         throw new InvalidOperationException(
-            $"Unsupported Optimization:DispatchMode '{dispatchMode}'. Supported values are RabbitMq and AzureServiceBus.");
+            $"Unsupported optimization dispatch mode '{dispatchMode}'. Supported values are RabbitMq, AzureServiceBus, and OptimizationMessaging:Transport values RabbitMQ or ServiceBus.");
     }
 
     var missing = requiredKeys
@@ -221,7 +221,20 @@ static bool UseAzureServiceBusDispatch(IConfiguration config) =>
     string.Equals(
         config["Optimization:DispatchMode"],
         "AzureServiceBus",
+        StringComparison.OrdinalIgnoreCase)
+    || string.Equals(
+        config["OptimizationMessaging:Transport"],
+        "ServiceBus",
         StringComparison.OrdinalIgnoreCase);
+
+static string OptimizationDispatchMode(IConfiguration config) =>
+    config["Optimization:DispatchMode"]
+    ?? config["OptimizationMessaging:Transport"]
+    ?? "RabbitMq";
+
+static bool IsRabbitMqDispatch(string dispatchMode) =>
+    string.Equals(dispatchMode, "RabbitMq", StringComparison.OrdinalIgnoreCase)
+    || string.Equals(dispatchMode, "RabbitMQ", StringComparison.OrdinalIgnoreCase);
 
 static bool UseAzureSignalRService(IConfiguration config, IHostEnvironment environment) =>
     environment.IsProduction() &&
@@ -249,13 +262,3 @@ static string[] GetAllowedCorsOrigins(IConfiguration config) {
 }
 
 public partial class Program { }
-
-internal sealed class DisabledLegacyOptimizationMessageBus : IMessageBus {
-    public Task PublishAsync<T>(string queueName, T message) =>
-        throw new InvalidOperationException(
-            "RabbitMQ optimization messaging is disabled because Optimization:DispatchMode is AzureServiceBus.");
-
-    public IDisposable Subscribe<T>(string queueName, Func<T, Task> onMessage) =>
-        throw new InvalidOperationException(
-            "RabbitMQ optimization messaging is disabled because Optimization:DispatchMode is AzureServiceBus.");
-}

--- a/src/Planner.API/appsettings.Development.json
+++ b/src/Planner.API/appsettings.Development.json
@@ -8,5 +8,8 @@
     },
     "Database": {
         "ResetAndSeed": false
+    },
+    "Optimization": {
+        "WorkerResultApiKey": "planner-dev-worker-result-key"
     }
 }

--- a/src/Planner.API/appsettings.json
+++ b/src/Planner.API/appsettings.json
@@ -9,6 +9,9 @@
     "Optimization": {
         "DispatchMode": "RabbitMq"
     },
+    "OptimizationMessaging": {
+        "Transport": "RabbitMQ"
+    },
     "Cosmos": {
         "DatabaseName": "planner",
         "OptimizationRunsContainerName": "optimizationRuns"

--- a/src/Planner.Application/Features/Optimization/OptimizationRequests.cs
+++ b/src/Planner.Application/Features/Optimization/OptimizationRequests.cs
@@ -7,6 +7,7 @@ using Planner.Contracts.Optimization;
 using Planner.Contracts.OptimizationRuns;
 using Planner.Messaging.Messaging;
 using Planner.Messaging.Optimization.Inputs;
+using Planner.Messaging.Optimization.Outputs;
 
 namespace Planner.Application.Features.Optimization;
 
@@ -41,15 +42,18 @@ public sealed record GetOptimizationRunInsightQuery(Guid OptimizationRunId)
 public sealed record BuildOptimizationRequestQuery(int? SearchTimeLimitSeconds)
     : IRequest<OptimizeRouteRequest>;
 
+public sealed record CompleteOptimizationRunCommand(OptimizeRouteResponse Response)
+    : IRequest<CommandResult>;
+
 public sealed class OptimizationCommandHandler(
     IMessageBus bus,
     IOptimizationRunSnapshotBuilder snapshotBuilder,
     IOptimizationRunStore runStore,
-    IOptimizationJobQueue jobQueue,
     ITenantContext tenant,
     IOptimizationRunNotificationPublisher notificationPublisher,
     IConfiguration configuration) :
-    IRequestHandler<SolveOptimizationCommand, CommandResult<OptimizationSummary>> {
+    IRequestHandler<SolveOptimizationCommand, CommandResult<OptimizationSummary>>,
+    IRequestHandler<CompleteOptimizationRunCommand, CommandResult> {
     public async Task<CommandResult<OptimizationSummary>> Handle(
         SolveOptimizationCommand command,
         CancellationToken cancellationToken) {
@@ -65,14 +69,12 @@ public sealed class OptimizationCommandHandler(
             return CommandResult<OptimizationSummary>.Rejected("No jobs or vehicles available for optimization.");
         }
 
-        if (UseAzureServiceBus()) {
+        if (UseAzureOptimizationDispatch()) {
             await runStore.CreateAsync(run, cancellationToken);
             await notificationPublisher.PublishRunChangedAsync(run.ToRunChangedDto(), cancellationToken);
 
             try {
-                await jobQueue.EnqueueAsync(
-                    new OptimizationJobMessage(run.TenantId, run.OptimizationRunId),
-                    cancellationToken);
+                await bus.PublishAsync(MessageRoutes.Request, request);
                 await runStore.MarkQueuedAsync(run.TenantId, run.OptimizationRunId, cancellationToken);
                 await notificationPublisher.PublishRunChangedAsync(
                     (run with {
@@ -114,10 +116,56 @@ public sealed class OptimizationCommandHandler(
         return CommandResult<OptimizationSummary>.Succeeded(summary);
     }
 
-    private bool UseAzureServiceBus() =>
+    public async Task<CommandResult> Handle(
+        CompleteOptimizationRunCommand command,
+        CancellationToken cancellationToken) {
+        var response = command.Response;
+        if (response.TenantId == Guid.Empty) {
+            return CommandResult.Rejected("TenantId missing.");
+        }
+
+        if (response.OptimizationRunId == Guid.Empty) {
+            return CommandResult.Rejected("OptimizationRunId missing.");
+        }
+
+        var run = await runStore.GetAsync(
+            response.TenantId,
+            response.OptimizationRunId,
+            cancellationToken);
+        if (run is null) {
+            return CommandResult.NotFound();
+        }
+
+        await runStore.SaveSolverResultAsync(
+            response.TenantId,
+            response.OptimizationRunId,
+            response,
+            cancellationToken);
+
+        var updated = await runStore.GetAsync(
+            response.TenantId,
+            response.OptimizationRunId,
+            cancellationToken);
+        if (updated is not null) {
+            await notificationPublisher.PublishRunChangedAsync(
+                updated.ToRunChangedDto(),
+                cancellationToken);
+        }
+
+        return CommandResult.Succeeded();
+    }
+
+    private bool UseAzureOptimizationDispatch() =>
+        IsAzureOptimizationDispatch(configuration);
+
+    private static bool IsAzureOptimizationDispatch(IConfiguration configuration) =>
         string.Equals(
             configuration["Optimization:DispatchMode"],
             "AzureServiceBus",
+            StringComparison.OrdinalIgnoreCase)
+        || string.Equals(
+            configuration["OptimizationMessaging:Transport"],
+            "ServiceBus",
             StringComparison.OrdinalIgnoreCase);
 }
 

--- a/src/Planner.Infrastructure/Planner.Infrastructure.csproj
+++ b/src/Planner.Infrastructure/Planner.Infrastructure.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Planner.Application\Planner.Application.csproj" />
     <ProjectReference Include="..\Planner.Domain\Planner.Domain.csproj" />
+    <ProjectReference Include="..\Planner.Messaging\Planner.Messaging.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -13,6 +14,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Planner.Infrastructure/ServiceBus/AzureOptimizationMessageBus.cs
+++ b/src/Planner.Infrastructure/ServiceBus/AzureOptimizationMessageBus.cs
@@ -1,0 +1,219 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Planner.Application.OptimizationRuns;
+using Planner.Contracts.OptimizationRuns;
+using Planner.Messaging.Messaging;
+using Planner.Messaging.Optimization.Inputs;
+using Planner.Messaging.Optimization.Outputs;
+
+namespace Planner.Infrastructure.ServiceBus;
+
+public sealed class AzureOptimizationMessageBus(
+    IOptimizationJobQueue jobQueue,
+    IOptimizationRunStore runStore,
+    IHttpClientFactory httpClientFactory,
+    IConfiguration configuration,
+    ILogger<AzureOptimizationMessageBus> logger) : IMessageBus {
+
+    public const string HttpClientName = "PlannerOptimizationResultApi";
+    private const string WorkerResultApiKeyHeader = "X-Optimization-Worker-Key";
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public Task PublishAsync<T>(string queueName, T message) {
+        if (queueName == MessageRoutes.Request) {
+            return PublishRequestAsync(message);
+        }
+
+        if (queueName == MessageRoutes.Response) {
+            return PublishResponseAsync(message);
+        }
+
+        throw new NotSupportedException(
+            $"Azure optimization messaging does not support route '{queueName}'.");
+    }
+
+    public IDisposable Subscribe<T>(string queueName, Func<T, Task> onMessage) {
+        if (queueName != MessageRoutes.Request || typeof(T) != typeof(OptimizeRouteRequest)) {
+            throw new NotSupportedException(
+                "Azure optimization messaging only supports subscribing to optimization requests.");
+        }
+
+        var cts = new CancellationTokenSource();
+        var task = Task.Run(
+            () => ProcessRequestsAsync(
+                async request => await onMessage((T)(object)request),
+                cts.Token),
+            CancellationToken.None);
+
+        return new Subscription(cts, task);
+    }
+
+    private Task PublishRequestAsync<T>(T message) {
+        var job = message switch {
+            OptimizationJobMessage jobMessage => jobMessage,
+            OptimizeRouteRequest request => new OptimizationJobMessage(
+                request.TenantId,
+                request.OptimizationRunId),
+            _ => throw new NotSupportedException(
+                $"Azure optimization request publishing does not support message type '{typeof(T).FullName}'.")
+        };
+
+        return jobQueue.EnqueueAsync(job, CancellationToken.None);
+    }
+
+    private Task PublishResponseAsync<T>(T message) {
+        if (message is not OptimizeRouteResponse response) {
+            throw new NotSupportedException(
+                $"Azure optimization response publishing does not support message type '{typeof(T).FullName}'.");
+        }
+
+        return UploadResultAsync(response, CancellationToken.None);
+    }
+
+    private async Task ProcessRequestsAsync(
+        Func<OptimizeRouteRequest, Task> onMessage,
+        CancellationToken ct) {
+        logger.LogInformation("Azure optimization message bus listening for Service Bus optimization jobs.");
+
+        while (!ct.IsCancellationRequested) {
+            try {
+                var envelope = await jobQueue.ReceiveOneAsync(ct);
+                if (envelope is null) {
+                    continue;
+                }
+
+                await ProcessEnvelopeAsync(envelope, onMessage, ct);
+            } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                break;
+            } catch (Exception ex) {
+                logger.LogError(ex, "Error receiving Azure optimization job; retrying.");
+                await DelayAfterReceiveFailureAsync(ct);
+            }
+        }
+    }
+
+    private async Task ProcessEnvelopeAsync(
+        IOptimizationJobEnvelope envelope,
+        Func<OptimizeRouteRequest, Task> onMessage,
+        CancellationToken ct) {
+        if (envelope.DeserializationException is not null || envelope.Message is null) {
+            await envelope.DeadLetterAsync(
+                "InvalidOptimizationJobMessage",
+                envelope.DeserializationException?.Message ?? "Optimization job message body was empty.",
+                ct);
+            return;
+        }
+
+        var job = envelope.Message;
+        var run = await runStore.GetAsync(job.TenantId, job.OptimizationRunId, ct);
+        if (run is null) {
+            var maxMissingRunDeliveries = GetMaxMissingRunDeliveries();
+            if (envelope.DeliveryCount >= maxMissingRunDeliveries) {
+                await envelope.DeadLetterAsync(
+                    "OptimizationRunNotFound",
+                    $"Optimization run {job.OptimizationRunId} for tenant {job.TenantId} was not found in Cosmos.",
+                    ct);
+            } else {
+                await envelope.AbandonAsync(ct);
+            }
+
+            return;
+        }
+
+        try {
+            await onMessage(run.RequestSnapshot);
+
+            // The worker handler publishes the solver response through this bus. In Azure mode
+            // that publish uploads to the API, so completion only happens after the API succeeds.
+            await envelope.CompleteAsync(ct);
+        } catch (Exception ex) {
+            logger.LogError(
+                ex,
+                "Optimization job {RunId} for tenant {TenantId} failed before the result was persisted.",
+                job.OptimizationRunId,
+                job.TenantId);
+            await envelope.AbandonAsync(ct);
+        }
+    }
+
+    private async Task UploadResultAsync(
+        OptimizeRouteResponse response,
+        CancellationToken ct) {
+        var baseUrl = GetPlannerApiBaseUrl();
+        var requestUri = new Uri(
+            new Uri($"{baseUrl.TrimEnd('/')}/"),
+            $"api/vrp/runs/{response.OptimizationRunId}/result");
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, requestUri) {
+            Content = JsonContent.Create(response, options: JsonOptions)
+        };
+
+        var workerResultApiKey = configuration["Optimization:WorkerResultApiKey"];
+        if (!string.IsNullOrWhiteSpace(workerResultApiKey)) {
+            request.Headers.Add(WorkerResultApiKeyHeader, workerResultApiKey);
+        }
+
+        var client = httpClientFactory.CreateClient(HttpClientName);
+        using var httpResponse = await client.SendAsync(request, ct);
+        if (httpResponse.IsSuccessStatusCode) {
+            logger.LogInformation(
+                "Uploaded optimization result for tenant {TenantId}, run {RunId}.",
+                response.TenantId,
+                response.OptimizationRunId);
+            return;
+        }
+
+        var responseBody = await httpResponse.Content.ReadAsStringAsync(ct);
+        throw new HttpRequestException(
+            $"Planner API rejected optimization result for run {response.OptimizationRunId}. "
+            + $"Status {(int)httpResponse.StatusCode} {httpResponse.ReasonPhrase}. {responseBody}");
+    }
+
+    private string GetPlannerApiBaseUrl() {
+        var baseUrl = FirstNonWhiteSpace(
+            configuration["PlannerApi:BaseUrl"],
+            configuration["SignalR:Server"]);
+
+        if (baseUrl is null) {
+            throw new InvalidOperationException(
+                "PlannerApi:BaseUrl is required for Azure optimization worker result uploads.");
+        }
+
+        return baseUrl;
+    }
+
+    private int GetMaxMissingRunDeliveries() =>
+        int.TryParse(configuration["Optimization:MaxMissingRunDeliveries"], out var value) && value > 0
+            ? value
+            : 3;
+
+    private static async Task DelayAfterReceiveFailureAsync(CancellationToken ct) {
+        try {
+            await Task.Delay(TimeSpan.FromSeconds(5), ct);
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            // normal shutdown
+        }
+    }
+
+    private static string? FirstNonWhiteSpace(params string?[] values) =>
+        values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))?.Trim();
+
+    private sealed class Subscription(
+        CancellationTokenSource cancellationTokenSource,
+        Task processingTask) : IDisposable {
+
+        public void Dispose() {
+            cancellationTokenSource.Cancel();
+
+            try {
+                processingTask.GetAwaiter().GetResult();
+            } catch (OperationCanceledException) {
+                // normal shutdown
+            } finally {
+                cancellationTokenSource.Dispose();
+            }
+        }
+    }
+}

--- a/src/Planner.Infrastructure/ServiceRegistration.cs
+++ b/src/Planner.Infrastructure/ServiceRegistration.cs
@@ -1,12 +1,14 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Planner.Application;
-using Planner.Application.Persistence;
 using Planner.Application.OptimizationRuns;
+using Planner.Application.Persistence;
 using Planner.Infrastructure.OptimizationRuns;
 using Planner.Infrastructure.Persistence;
 using Planner.Infrastructure.ServiceBus;
+using Planner.Messaging.Messaging;
 
 namespace Planner.Infrastructure;
 
@@ -34,8 +36,15 @@ public static class ServiceRegistration {
     }
 
     public static IServiceCollection AddOptimizationRunInfrastructure(this IServiceCollection services) {
-        services.AddSingleton<IOptimizationRunStore, CosmosOptimizationRunStore>();
-        services.AddSingleton<IOptimizationJobQueue, ServiceBusOptimizationJobQueue>();
+        services.TryAddSingleton<IOptimizationRunStore, CosmosOptimizationRunStore>();
+        services.TryAddSingleton<IOptimizationJobQueue, ServiceBusOptimizationJobQueue>();
+        return services;
+    }
+
+    public static IServiceCollection AddAzureOptimizationMessaging(this IServiceCollection services) {
+        services.AddOptimizationRunInfrastructure();
+        services.AddHttpClient(AzureOptimizationMessageBus.HttpClientName);
+        services.AddSingleton<IMessageBus, AzureOptimizationMessageBus>();
         return services;
     }
 }

--- a/src/Planner.Optimization.Worker/BackgroundServices/OptimizationWorker.cs
+++ b/src/Planner.Optimization.Worker/BackgroundServices/OptimizationWorker.cs
@@ -1,19 +1,22 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Planner.Optimization.Worker.Handlers;
-using Planner.Messaging.RabbitMQ;
 using Planner.Messaging.Messaging;
 using Planner.Messaging.Optimization.Inputs;
+using Planner.Messaging.RabbitMQ;
+using Planner.Optimization.Worker.Handlers;
 
 namespace Planner.Optimization.Worker.BackgroundServices;
 
 public sealed class OptimizationWorker(
     IMessageBus bus,
     IServiceProvider serviceProvider,
-    IRabbitMqConnection rabbit) : BackgroundService {
+    IConfiguration configuration) : BackgroundService {
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken) {
-        PurgeQueues();
+        if (!UseAzureOptimizationDispatch()) {
+            PurgeQueues();
+        }
 
         using var subscription = bus.Subscribe<OptimizeRouteRequest>(
             MessageRoutes.Request,
@@ -34,6 +37,7 @@ public sealed class OptimizationWorker(
     }
 
     private void PurgeQueues() {
+        var rabbit = serviceProvider.GetRequiredService<IRabbitMqConnection>();
         using var channel = rabbit.CreateChannel();
 
         channel.QueueDeclare(MessageRoutes.Request, durable: true, exclusive: false, autoDelete: false, arguments: null);
@@ -42,4 +46,14 @@ public sealed class OptimizationWorker(
         channel.QueuePurge(MessageRoutes.Request);
         channel.QueuePurge(MessageRoutes.Response);
     }
+
+    private bool UseAzureOptimizationDispatch() =>
+        string.Equals(
+            configuration["Optimization:DispatchMode"],
+            "AzureServiceBus",
+            StringComparison.OrdinalIgnoreCase)
+        || string.Equals(
+            configuration["OptimizationMessaging:Transport"],
+            "ServiceBus",
+            StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Planner.Optimization.Worker/Planner.Optimization.Worker.csproj
+++ b/src/Planner.Optimization.Worker/Planner.Optimization.Worker.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Planner.Infrastructure\Planner.Infrastructure.csproj" />
     <ProjectReference Include="..\Planner.Messaging\Planner.Messaging.csproj" />
     <ProjectReference Include="..\Planner.Optimization\Planner.Optimization.csproj" />
   </ItemGroup>

--- a/src/Planner.Optimization.Worker/Program.cs
+++ b/src/Planner.Optimization.Worker/Program.cs
@@ -1,19 +1,25 @@
-﻿using Planner.Optimization.Worker.BackgroundServices;
-using Planner.Optimization.Worker.Handlers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Hosting;
-using Planner.Optimization;
+using Microsoft.Extensions.Logging;
+using Planner.Infrastructure;
 using Planner.Messaging;
+using Planner.Optimization;
+using Planner.Optimization.Worker.BackgroundServices;
+using Planner.Optimization.Worker.Handlers;
 
 var builder = Host.CreateApplicationBuilder(args);
 builder.Configuration.AddEnvironmentVariables();
+var useAzureOptimizationDispatch = UseAzureOptimizationDispatch(builder.Configuration);
 
 var loggerFactory = LoggerFactory.Create(config => {
     config.AddConsole();
 });
 var logger = loggerFactory.CreateLogger("Startup");
+
+logger.LogInformation(
+    "Optimization worker dispatch mode: {DispatchMode}",
+    useAzureOptimizationDispatch ? "AzureServiceBus" : "RabbitMq");
 
 // =========================================================
 // SERVICES
@@ -23,14 +29,28 @@ builder.Logging.ClearProviders();
 builder.Logging.AddConsole();
 
 // Shared infrastructure
-builder.Services.AddMessagingBus();
+if (useAzureOptimizationDispatch) {
+    builder.Services.AddAzureOptimizationMessaging();
+} else {
+    builder.Services.AddMessagingBus();
+}
 
 // --- Optimization ---
 builder.Services.AddOptimization();
 
-// Your worker services
+// Worker services
 builder.Services.AddHostedService<OptimizationWorker>();
 builder.Services.AddTransient<IOptimizationRequestHandler, OptimizationRequestHandler>();
 
 var host = builder.Build();
 await host.RunAsync();
+
+static bool UseAzureOptimizationDispatch(IConfiguration configuration) =>
+    string.Equals(
+        configuration["Optimization:DispatchMode"],
+        "AzureServiceBus",
+        StringComparison.OrdinalIgnoreCase)
+    || string.Equals(
+        configuration["OptimizationMessaging:Transport"],
+        "ServiceBus",
+        StringComparison.OrdinalIgnoreCase);

--- a/src/Planner.Optimization.Worker/appsettings.Development.json
+++ b/src/Planner.Optimization.Worker/appsettings.Development.json
@@ -5,5 +5,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Optimization": {
+    "WorkerResultApiKey": "planner-dev-worker-result-key"
   }
 }

--- a/src/Planner.Optimization.Worker/appsettings.json
+++ b/src/Planner.Optimization.Worker/appsettings.json
@@ -5,5 +5,21 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Optimization": {
+    "DispatchMode": "RabbitMq"
+  },
+  "OptimizationMessaging": {
+    "Transport": "RabbitMQ"
+  },
+  "Cosmos": {
+    "DatabaseName": "planner",
+    "OptimizationRunsContainerName": "optimizationRuns"
+  },
+  "ServiceBus": {
+    "OptimizationQueueName": "optimization-jobs"
+  },
+  "PlannerApi": {
+    "BaseUrl": "http://localhost:5000"
+  }
 }

--- a/test/Planner.API.EndToEndTests/Fixtures/TestApiFactory.cs
+++ b/test/Planner.API.EndToEndTests/Fixtures/TestApiFactory.cs
@@ -27,7 +27,8 @@ public sealed class TestApiFactory : IDisposable {
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Optimization:DispatchMode"] = dispatchMode
+                ["Optimization:DispatchMode"] = dispatchMode,
+                ["Optimization:WorkerResultApiKey"] = "test-worker-result-key"
             })
             .Build());
 
@@ -111,7 +112,12 @@ public sealed class TestApiFactory : IDisposable {
 
         public Task SaveSolverResultAsync(Guid tenantId, Guid runId, OptimizeRouteResponse result, CancellationToken ct) {
             if (Runs.TryGetValue(runId, out var run)) {
-                Runs[runId] = run with { SolverResult = result };
+                Runs[runId] = run with {
+                    SolverResult = result,
+                    Status = string.IsNullOrWhiteSpace(result.ErrorMessage)
+                        ? OptimizationRunStatus.Succeeded
+                        : OptimizationRunStatus.Failed
+                };
             }
 
             return Task.CompletedTask;

--- a/test/Planner.API.EndToEndTests/OptimizationController.EndToEndTests.cs
+++ b/test/Planner.API.EndToEndTests/OptimizationController.EndToEndTests.cs
@@ -6,11 +6,14 @@ using Planner.Application;
 using Planner.Infrastructure.Persistence;
 using Planner.Messaging.Messaging;
 using Planner.Messaging.Optimization.Inputs;
+using Planner.Messaging.Optimization.Outputs;
 using Planner.Testing;
 using Planner.Application.OptimizationRuns;
+using Planner.Contracts.OptimizationRuns;
 using Planner.Domain;
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -81,7 +84,8 @@ public sealed class OptimizationControllerEndToEndTests {
         queue.Messages.Should().ContainSingle();
         queue.Messages[0].TenantId.Should().Be(tenant.TenantId);
         queue.Messages[0].OptimizationRunId.Should().Be(store.Runs.Single().Key);
-        bus!.PublishedMessages.Should().BeEmpty();
+        bus!.PublishedMessages.Should().ContainSingle(m =>
+            m.Route == MessageRoutes.Request);
     }
 
     [Fact]
@@ -110,6 +114,38 @@ public sealed class OptimizationControllerEndToEndTests {
         run.RequestSnapshot.TenantId.Should().Be(tenant.TenantId);
         run.RequestSnapshot.Vehicles.Should().ContainSingle(v => v.VehicleId == 1);
         run.RequestSnapshot.Stops.Select(s => s.LocationId).Should().BeEquivalentTo([1L, 2L]);
+    }
+
+    [Fact]
+    public async Task CompleteRun_endpoint_persists_solver_result_in_azure_mode() {
+        using var factory = new TestApiFactory(dispatchMode: "AzureServiceBus");
+
+        var tenant = factory.Get<ITenantContext>();
+        var db = factory.Get<PlannerDbContext>();
+        var controller = factory.Get<OptimizationController>();
+        controller.MockUserContext();
+        controller.Request.Headers["X-Optimization-Worker-Key"] = "test-worker-result-key";
+
+        DomainSeed.SeedSmallScenario(db, tenant.TenantId);
+        await db.SaveChangesAsync();
+
+        var solveResult = await controller.Solve();
+        solveResult.Should().BeOfType<OkObjectResult>();
+
+        var store = (TestApiFactory.InMemoryOptimizationRunStore)factory.Get<IOptimizationRunStore>();
+        var run = store.Runs.Values.Single();
+        var response = new OptimizeRouteResponse(
+            run.TenantId,
+            run.OptimizationRunId,
+            DateTime.UtcNow,
+            [],
+            0);
+
+        var result = await controller.CompleteRun(run.OptimizationRunId, response, CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        store.Runs[run.OptimizationRunId].SolverResult.Should().Be(response);
+        store.Runs[run.OptimizationRunId].Status.Should().Be(OptimizationRunStatus.Succeeded);
     }
 
     private static void SeedOtherTenantSmallScenario(PlannerDbContext db, Guid tenantId) {

--- a/test/Planner.Optimization.IntegrationTests/Fixtures/FakeMessageBus.cs
+++ b/test/Planner.Optimization.IntegrationTests/Fixtures/FakeMessageBus.cs
@@ -1,20 +1,48 @@
-﻿using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+using Microsoft.Extensions.Configuration;
+using Planner.Application.OptimizationRuns;
+using Planner.Contracts.OptimizationRuns;
 using Planner.Messaging.Messaging;
+using Planner.Messaging.Optimization.Inputs;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Planner.API.EndToEndTests.Fixtures;
 
-public sealed class FakeMessageBus : IMessageBus {
+public sealed class FakeMessageBus(
+    IConfiguration configuration,
+    IOptimizationJobQueue jobQueue) : IMessageBus {
+
     public List<(string Route, object Message)> PublishedMessages { get; } = [];
 
-    public Task PublishAsync<T>(string queueName, T message) {
-        PublishedMessages.Add((queueName, message));
-        return Task.CompletedTask;
+    public async Task PublishAsync<T>(string queueName, T message) {
+        PublishedMessages.Add((queueName, message!));
+
+        if (UseAzureOptimizationDispatch()
+            && queueName == MessageRoutes.Request
+            && message is OptimizeRouteRequest request) {
+            await jobQueue.EnqueueAsync(
+                new OptimizationJobMessage(request.TenantId, request.OptimizationRunId),
+                CancellationToken.None);
+        }
     }
 
-    IDisposable IMessageBus.Subscribe<T>(string queueName, Func<T, Task> onMessage) {
-        return null;
+    IDisposable IMessageBus.Subscribe<T>(string queueName, Func<T, Task> onMessage) =>
+        new Disposable();
+
+    private bool UseAzureOptimizationDispatch() =>
+        string.Equals(
+            configuration["Optimization:DispatchMode"],
+            "AzureServiceBus",
+            StringComparison.OrdinalIgnoreCase)
+        || string.Equals(
+            configuration["OptimizationMessaging:Transport"],
+            "ServiceBus",
+            StringComparison.OrdinalIgnoreCase);
+
+    private sealed class Disposable : IDisposable {
+        public void Dispose() {
+        }
     }
 }


### PR DESCRIPTION
Closes #87

## Summary
- Add an Azure `IMessageBus` adapter that publishes lightweight Service Bus jobs, loads optimization run snapshots from Cosmos, and uploads solver results back to Planner API.
- Wire Planner API and `Planner.Optimization.Worker` to select Azure dispatch through `Optimization:DispatchMode=AzureServiceBus` or `OptimizationMessaging:Transport=ServiceBus` while preserving RabbitMQ as the default path.
- Add a secured worker result endpoint that persists solver output and publishes tenant-scoped run summary notifications.
- Update local/dev and Docker Compose configuration for Service Bus/Cosmos emulator mode.
- Extend tests for Azure dispatch and result persistence.

## Architecture Notes
- The solver handler remains transport-agnostic: it consumes `OptimizeRouteRequest` and publishes `OptimizeRouteResponse` through `IMessageBus`.
- Azure mode stores the full run/input in Cosmos and puts only tenant/run identifiers on Service Bus.
- Service Bus messages are completed only after the worker has uploaded the solver result and the API has accepted it.
- RabbitMQ remains available as the playground/legacy transport.

## Test Results
- `dotnet build` passed.
- `dotnet test` passed.

## Risks / Follow-up
- Azure emulator mode still needs manual verification with local Service Bus and Cosmos containers running.
- Production Azure deployments must configure `Optimization:WorkerResultApiKey`, Service Bus connection settings, Cosmos settings, and `PlannerApi:BaseUrl` for the worker.