### PR TITLE
chore: tidy local docker tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,17 +3,6 @@
 ##
 ## Get latest from `dotnet new gitignore`
 
-# dotenv files
-.env
-.env.local
-.env.*.local
-.env.azure
-src/**/local.settings.json
-
-# Firebase credentials (sensitive)
-*firebase-credentials.json
-*-firebase-adminsdk-*.json
-
 # User-specific files
 *.rsuser
 *.suo
@@ -492,27 +481,52 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
-/src/Shared
-/publish-api
-/publish-blazor
+
+################################################################################
+# Planner project-specific ignores
+################################################################################
+
+# Local environment files and secrets.
+# Shared examples should use committed *.example files instead.
+.env
+.env.local
+.env.*.local
+.env.azure
+src/**/local.settings.json
+/src/Credentials/
+*firebase-credentials.json
+*-firebase-adminsdk-*.json
+
+# Local-only PowerShell helpers.
+# Repo scripts under scripts/ are intentionally trackable; use *.local.ps1 for
+# private machine-specific variants.
 /PS deployment.ps1
+/setup-planner-cicd.ps1
+*.local.ps1
+
+# Local publish output and deployment archives.
+/publish-api/
+/publish-blazor/
 /publish-api.zip
 /publish-blazor.zip
-/setup-planner-cicd.ps1
-/temp
-/src/SharedXX
-/Properties
-/src/Planner.BlazorApp/Properties
-/src/Planner.API/Properties
-/src/Planner.Optimization.Worker/Properties
-/src/Planner.BlazorApp/wwwroot/data
-/aip
-*.ps1
-!/scripts/azure/*.ps1
-*.txt
+/temp/
+/aip/
+
+# Local/generated project folders.
+/src/Shared/
+/src/SharedXX/
+/Properties/
+/src/Planner.BlazorApp/Properties/
+/src/Planner.API/Properties/
+/src/Planner.Optimization.Worker/Properties/
+/src/Planner.BlazorApp/wwwroot/data/
 /tools/Planner.Tools.DbMigrator/Properties/launchSettings.json
-/src/Credentials
-AI prompts/
+
+# Generated infrastructure output.
 infra/main.json
 infra/.last-deployment-outputs.json
+
+# Local notes, prompt scratch space, and current-work docs.
+*.txt
+AI prompts/
 docs/current/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,19 @@ services:
   # SQL Server
   sqlserver:
     image: mcr.microsoft.com/mssql/server:2022-latest
+    deploy:
+      resources:
+        limits:
+          memory: 4g  # Adjust based on your available host memory
+        reservations:
+          memory: 2g
     container_name: sqlserver
     ports:
       - "1433:1433"
     environment:
       - ACCEPT_EULA=Y
       - MSSQL_SA_PASSWORD=PlannerDevPass123
+      - MSSQL_MEMORY_LIMIT_MB=2048  # Limits SQL to 2GB instead of all available
     volumes:
       - sqlserver_data:/var/opt/mssql
 

--- a/scripts/start-blazor-with-docker.cmd
+++ b/scripts/start-blazor-with-docker.cmd
@@ -1,0 +1,20 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+set "PS_SCRIPT=%SCRIPT_DIR%start-blazor-with-docker.ps1"
+
+where pwsh >nul 2>nul
+if %ERRORLEVEL% EQU 0 (
+    pwsh -NoProfile -ExecutionPolicy Bypass -File "%PS_SCRIPT%" %*
+    exit /b %ERRORLEVEL%
+)
+
+where powershell >nul 2>nul
+if %ERRORLEVEL% EQU 0 (
+    powershell -NoProfile -ExecutionPolicy Bypass -File "%PS_SCRIPT%" %*
+    exit /b %ERRORLEVEL%
+)
+
+echo Neither pwsh nor powershell was found on PATH.
+exit /b 1

--- a/scripts/start-blazor-with-docker.ps1
+++ b/scripts/start-blazor-with-docker.ps1
@@ -1,0 +1,215 @@
+param(
+    [ValidateSet("RabbitMQ", "ServiceBus")]
+    [string]$Transport = "RabbitMQ",
+
+    [switch]$NoBuild,
+    [switch]$ForceRecreate,
+    [switch]$SkipDocker,
+    [switch]$SkipBlazor,
+    [switch]$DetachedBlazor,
+    [switch]$WaitForBlazor,
+
+    [int]$BlazorTimeoutSeconds = 90,
+
+    [string[]]$Services = @()
+)
+
+$ErrorActionPreference = "Stop"
+
+function Test-CommandAvailable {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Get-DockerComposeCommand {
+    if (Test-CommandAvailable "docker") {
+        & docker compose version *> $null
+        if ($LASTEXITCODE -eq 0) {
+            return @{
+                File = "docker"
+                Prefix = @("compose")
+            }
+        }
+    }
+
+    if (Test-CommandAvailable "docker-compose") {
+        return @{
+            File = "docker-compose"
+            Prefix = @()
+        }
+    }
+
+    throw "Neither 'docker compose' nor 'docker-compose' is available on PATH."
+}
+
+function Invoke-NativeCommand {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][string[]]$ArgumentList
+    )
+
+    Write-Host "> $FilePath $($ArgumentList -join ' ')"
+    & $FilePath @ArgumentList
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Start-BlazorDetached {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepoRoot,
+        [Parameter(Mandatory = $true)][string]$ProjectPath
+    )
+
+    $dotnetArgs = @(
+        "run",
+        "--project",
+        $ProjectPath,
+        "--launch-profile",
+        "Planner.BlazorApp"
+    )
+
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = "dotnet"
+    $startInfo.WorkingDirectory = $RepoRoot
+    $startInfo.UseShellExecute = $false
+
+    foreach ($arg in $dotnetArgs) {
+        [void]$startInfo.ArgumentList.Add($arg)
+    }
+
+    $process = [System.Diagnostics.Process]::Start($startInfo)
+    if ($null -eq $process) {
+        throw "Failed to start Planner.BlazorApp."
+    }
+
+    Write-Host "Planner.BlazorApp started in the background. PID: $($process.Id)"
+    return $process
+}
+
+function Wait-ForBlazor {
+    param(
+        [Parameter(Mandatory = $true)][string]$Url,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    Write-Host "Waiting for Planner.BlazorApp at $Url..."
+
+    do {
+        try {
+            $response = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 5
+            if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 500) {
+                Write-Host "Planner.BlazorApp responded with HTTP $($response.StatusCode)."
+                return
+            }
+        } catch {
+            Start-Sleep -Seconds 2
+        }
+    } while ((Get-Date) -lt $deadline)
+
+    throw "Planner.BlazorApp did not respond at $Url within $TimeoutSeconds seconds."
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$composeFile = Join-Path $repoRoot "docker-compose.yml"
+$blazorProject = Join-Path $repoRoot "src\Planner.BlazorApp\Planner.BlazorApp.csproj"
+
+Push-Location $repoRoot
+try {
+    if (-not (Test-Path $composeFile)) {
+        throw "Cannot find docker-compose.yml at $composeFile."
+    }
+
+    if (-not (Test-Path $blazorProject)) {
+        throw "Cannot find Planner.BlazorApp project at $blazorProject."
+    }
+
+    if (-not $SkipDocker) {
+        $compose = Get-DockerComposeCommand
+
+        if ($Transport -eq "ServiceBus") {
+            $env:OPTIMIZATION_DISPATCH_MODE = "AzureServiceBus"
+            $env:OPTIMIZATION_MESSAGING_TRANSPORT = "ServiceBus"
+        } else {
+            $env:OPTIMIZATION_DISPATCH_MODE = "RabbitMq"
+            $env:OPTIMIZATION_MESSAGING_TRANSPORT = "RabbitMQ"
+            Remove-Item Env:\COMPOSE_PROFILES -ErrorAction SilentlyContinue
+        }
+
+        $composeArgs = @()
+        $composeArgs += $compose.Prefix
+        $composeArgs += @("-f", $composeFile)
+
+        if ($Transport -eq "ServiceBus") {
+            $composeArgs += @("--profile", "azure-emulators")
+        }
+
+        $composeArgs += @("up", "-d")
+
+        if (-not $NoBuild) {
+            $composeArgs += "--build"
+        }
+
+        if ($ForceRecreate) {
+            $composeArgs += "--force-recreate"
+        }
+
+        if ($Services.Count -gt 0) {
+            $composeArgs += $Services
+        }
+
+        Write-Host ""
+        Write-Host "Updating Planner Docker stack..."
+        Write-Host "Transport: $Transport"
+        if ($Services.Count -gt 0) {
+            Write-Host "Services: $($Services -join ', ')"
+        } else {
+            Write-Host "Services: all active services in docker-compose.yml"
+        }
+        Write-Host ""
+
+        Invoke-NativeCommand -FilePath $compose.File -ArgumentList $composeArgs
+
+        $psArgs = @()
+        $psArgs += $compose.Prefix
+        $psArgs += @("-f", $composeFile)
+        if ($Transport -eq "ServiceBus") {
+            $psArgs += @("--profile", "azure-emulators")
+        }
+        $psArgs += "ps"
+
+        Write-Host ""
+        Invoke-NativeCommand -FilePath $compose.File -ArgumentList $psArgs
+    }
+
+    if ($SkipBlazor) {
+        Write-Host ""
+        Write-Host "Docker update complete. Skipped Planner.BlazorApp startup."
+        exit 0
+    }
+
+    if (-not (Test-CommandAvailable "dotnet")) {
+        throw "'dotnet' is not available on PATH."
+    }
+
+    Write-Host ""
+    Write-Host "Starting Planner.BlazorApp..."
+    Write-Host "UI:  https://localhost:7014"
+    Write-Host "API: http://localhost:7085"
+    Write-Host ""
+
+    if ($DetachedBlazor) {
+        $blazorProcess = Start-BlazorDetached -RepoRoot $repoRoot -ProjectPath $blazorProject
+        if ($WaitForBlazor) {
+            Wait-ForBlazor -Url "http://localhost:5212/dispatch-center" -TimeoutSeconds $BlazorTimeoutSeconds
+        }
+    } else {
+        & dotnet run --project $blazorProject --launch-profile Planner.BlazorApp
+        exit $LASTEXITCODE
+    }
+}
+finally {
+    Pop-Location
+}

--- a/scripts/update-worker-docker.ps1
+++ b/scripts/update-worker-docker.ps1
@@ -1,0 +1,24 @@
+param(
+  [string]$Tag = "planner-optimization-worker:dev",
+  [string]$ContainerName = "planner-optimization-worker"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+Write-Host "Building image $Tag..."
+docker build -f src/Planner.Optimization.Worker/Dockerfile -t $Tag .
+
+Write-Host "Restarting container $ContainerName..."
+docker rm -f $ContainerName 2>$null | Out-Null
+docker run -d --name $ContainerName --restart unless-stopped `
+  -e RabbitMq__Host=host.docker.internal `
+  -e RabbitMq__Port=5672 `
+  -e RabbitMq__User=guest `
+  -e RabbitMq__Pass=guest `
+  $Tag | Out-Null
+
+Write-Host "Done. Recent logs:"
+docker logs --tail 30 $ContainerName

--- a/src/Planner.Optimization.Worker/Dockerfile
+++ b/src/Planner.Optimization.Worker/Dockerfile
@@ -6,8 +6,17 @@ WORKDIR /src
 ARG TARGETARCH=amd64
 
 # Copy project files required by Worker restore graph
+COPY src/Planner.Application/Planner.Application.csproj \
+     src/Planner.Application/
+
 COPY src/Planner.Contracts/Planner.Contracts.csproj \
      src/Planner.Contracts/
+
+COPY src/Planner.Domain/Planner.Domain.csproj \
+     src/Planner.Domain/
+
+COPY src/Planner.Infrastructure/Planner.Infrastructure.csproj \
+     src/Planner.Infrastructure/
 
 COPY src/Planner.Messaging/Planner.Messaging.csproj \
      src/Planner.Messaging/
@@ -51,7 +60,7 @@ RUN case "$TARGETARCH" in \
 # ============================
 # Runtime stage
 # ============================
-FROM mcr.microsoft.com/dotnet/runtime:10.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 # Rely on the built-in Microsoft user
 USER app


### PR DESCRIPTION
## Summary

Housekeeping update for local Docker and script tooling. No product behavior change is intended.

- Add a `start-blazor-with-docker` PowerShell script plus `.cmd` wrapper for rebuilding/updating the Docker Compose stack and starting `Planner.BlazorApp`.
- Track the existing `scripts/update-worker-docker.ps1` script now that project PowerShell scripts are no longer globally ignored.
- Reorganize Planner-specific `.gitignore` rules into documented categories and replace broad `*.ps1` ignore behavior with `*.local.ps1`.
- Fix the optimization worker Docker image so Compose rebuilds work locally: include all project files needed by restore and use the ASP.NET runtime image required by the worker dependency graph.
- Add a local SQL Server memory cap in `docker-compose.yml` for a more predictable Docker Desktop footprint.

No GitHub issue was created for this PR per request.

## Validation

- `git diff --cached --check`
- `dotnet build`
- `dotnet test`
- `scripts\start-blazor-with-docker.cmd -DetachedBlazor -WaitForBlazor`
- Verified `http://localhost:5212/dispatch-center` returned HTTP 200 after script startup.
- Verified Docker Compose services were up, including `planner-api`, `planner-optimization-worker`, `rabbitmq`, `sqlserver`, and `planner-ai-worker`.

## Notes

`.vscode/launch.json` was left untracked and intentionally excluded from this PR.