### PR TITLE
Fix Entra login for Azure-hosted Blazor app

### DIFF
--- a/infra/modules/core.bicep
+++ b/infra/modules/core.bicep
@@ -839,6 +839,10 @@ resource apiApp 'Microsoft.App/containerApps@2024-03-01' = {
               value: 'https://${plannerHostName}'
             }
             {
+              name: 'Cors__AllowedOrigins__1'
+              value: 'https://${blazorApp.properties.defaultHostName}'
+            }
+            {
               name: 'RabbitMq__Host'
               value: rabbitMqApp.name
             }

--- a/scripts/azure/bootstrap-entra.ps1
+++ b/scripts/azure/bootstrap-entra.ps1
@@ -121,13 +121,18 @@ Set-GraphApplication -ObjectId $apiApp.id -Body @{
 $apiApp = Get-AppByDisplayName -DisplayName $ApiAppDisplayName
 
 $blazorApp = Ensure-App -DisplayName $BlazorAppDisplayName
+$blazorDefaultHostName = az webapp list --resource-group $ResourceGroupName --query "[0].defaultHostName" -o tsv
+$blazorRedirectUris = @(
+    "https://$PlannerHostName/authentication/login-callback",
+    "https://localhost:7014/authentication/login-callback",
+    "http://localhost:5212/authentication/login-callback"
+)
+if (-not [string]::IsNullOrWhiteSpace($blazorDefaultHostName)) {
+    $blazorRedirectUris += "https://$($blazorDefaultHostName.Trim())/authentication/login-callback"
+}
 Set-GraphApplication -ObjectId $blazorApp.id -Body @{
     spa = @{
-        redirectUris = @(
-            "https://$PlannerHostName/authentication/login-callback",
-            "https://localhost:7014/authentication/login-callback",
-            "http://localhost:5212/authentication/login-callback"
-        )
+        redirectUris = $blazorRedirectUris
     }
     isFallbackPublicClient = $true
     requiredResourceAccess = @(


### PR DESCRIPTION
Closes #90

## Summary
- register the deployed Blazor App Service default hostname as an Entra SPA callback during bootstrap
- preserve the custom-domain and localhost callbacks
- allow the App Service origin through Planner.API credentialed CORS

## Root cause
The Azure-hosted Blazor WebAssembly URL was not registered under the Entra application's SPA redirect URIs. The API CORS configuration also allowed only the planned custom domain, while the deployment currently uses the default `azurewebsites.net` hostname.

## Architecture notes
This change only adjusts deployment/bootstrap configuration. It preserves the RabbitMQ optimization path and does not enable or deploy AI Insight processing.

## Validation
- `dotnet build` — passed, 0 warnings and 0 errors
- `dotnet test --no-build` — all discovered tests passed
- deployed Blazor `/appsettings.json` — HTTP 200 with expected tenant, client ID, API scope, and SignalR provider
- API credentialed CORS preflight from the App Service origin — HTTP 204
- Entra authorize request using the App Service callback — HTTP 200

## Risks / follow-up
- The custom `planner.plannerdemo.com` and `api.plannerdemo.com` DNS/certificate bindings remain a separate deployment task.
- The unrelated local `.env.example` modification was intentionally excluded.