### PR TITLE
Fix Entra tenant resolution for authenticated API requests

### DIFF
--- a/src/Planner.API/Auth/EntraUserIdentity.cs
+++ b/src/Planner.API/Auth/EntraUserIdentity.cs
@@ -1,0 +1,29 @@
+using System.Security.Claims;
+
+namespace Planner.API.Auth;
+
+public static class EntraUserIdentity {
+    private static readonly string[] LoginClaimTypes = [
+        "preferred_username",
+        "upn",
+        ClaimTypes.Email,
+        "email"
+    ];
+
+    public static string? ResolveLogin(ClaimsPrincipal? principal) {
+        if (principal?.Identity?.IsAuthenticated != true) {
+            return null;
+        }
+
+        foreach (var claimType in LoginClaimTypes) {
+            var value = principal.FindFirst(claimType)?.Value;
+            if (!string.IsNullOrWhiteSpace(value)) {
+                return value.Trim();
+            }
+        }
+
+        return string.IsNullOrWhiteSpace(principal.Identity.Name)
+            ? null
+            : principal.Identity.Name.Trim();
+    }
+}

--- a/src/Planner.API/Hubs/PlannerHub.cs
+++ b/src/Planner.API/Hubs/PlannerHub.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Planner.Application.Persistence;
+using Planner.API.Auth;
 
 namespace Planner.API.Hubs;
 
@@ -30,7 +31,7 @@ public sealed class PlannerHub(
     }
 
     private async Task<Guid> ResolveTenantIdAsync() {
-        var email = Context.User?.Identity?.Name;
+        var email = EntraUserIdentity.ResolveLogin(Context.User);
         if (string.IsNullOrWhiteSpace(email)) {
             return Guid.Empty;
         }

--- a/src/Planner.API/Middleware/TenantContextMiddleware.cs
+++ b/src/Planner.API/Middleware/TenantContextMiddleware.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Planner.Application;
 using Planner.Application.Persistence;
+using Planner.API.Auth;
 using System.Security;
 
 namespace Planner.API.Middleware;
@@ -10,9 +11,9 @@ namespace Planner.API.Middleware;
 public sealed class TenantContextMiddleware(RequestDelegate next, ILogger<TenantContextMiddleware> logger) {
     public async Task InvokeAsync(HttpContext context, ITenantContext tenantContext, IMemoryCache cache, IPlannerDbContext db) {
         if (context.User.Identity?.IsAuthenticated == true) {
-            var email = context.User.Identity?.Name;
+            var email = EntraUserIdentity.ResolveLogin(context.User);
             if (!string.IsNullOrEmpty(email)) {
-                var cacheKey = $"TenantMapping_{email.ToLower()}";
+                var cacheKey = $"TenantMapping_{email.ToLowerInvariant()}";
                 
                 // 1. Try to get the TenantId from the fast memory cache
                 if (!cache.TryGetValue(cacheKey, out Guid tenantId)) {

--- a/test/Planner.API.Tests/EntraUserIdentityTests.cs
+++ b/test/Planner.API.Tests/EntraUserIdentityTests.cs
@@ -1,0 +1,31 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Planner.API.Auth;
+
+namespace Planner.API.Tests;
+
+public sealed class EntraUserIdentityTests {
+    [Fact]
+    public void ResolveLogin_PrefersPreferredUsernameOverDisplayName() {
+        var identity = new ClaimsIdentity([
+            new Claim(ClaimTypes.Name, "Christchurch Admin"),
+            new Claim("preferred_username", "christchurch.admin@plannerdemo.com")
+        ], "Bearer");
+
+        EntraUserIdentity.ResolveLogin(new ClaimsPrincipal(identity))
+            .Should().Be("christchurch.admin@plannerdemo.com");
+    }
+
+    [Theory]
+    [InlineData("upn")]
+    [InlineData(ClaimTypes.Email)]
+    [InlineData("email")]
+    public void ResolveLogin_UsesSupportedEmailClaims(string claimType) {
+        var identity = new ClaimsIdentity([
+            new Claim(claimType, "christchurch.admin@plannerdemo.com")
+        ], "Bearer");
+
+        EntraUserIdentity.ResolveLogin(new ClaimsPrincipal(identity))
+            .Should().Be("christchurch.admin@plannerdemo.com");
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared resolver for Entra login identifiers
- prefer `preferred_username`, `upn`, and email claims over display-name-based `Identity.Name`
- use identical tenant resolution for HTTP requests and SignalR connections
- cover the supported claim variants with unit tests

## Root cause
`TenantContextMiddleware` used only `User.Identity.Name` to look up `Users.Email`. In Azure Entra tokens this value can be the display name (for example, `Christchurch Admin`) while the mapped login email is carried in `preferred_username`. Authentication succeeded, but tenant resolution remained unset and `/api/config/init` returned `404`.

## Impact
Authenticated users whose login email is present in a standard Entra claim now resolve to the correct tenant. Tenant-scoped database queries and SignalR group assignment continue to use the resolved tenant ID; no cross-tenant lookup behavior changes.

## Validation
- `dotnet build Planner.sln -c Release` — passed, 0 warnings
- `dotnet test Planner.sln -c Release --no-build` — passed, 48 tests
- `Planner.Testing` is a shared utility assembly and reports no discoverable tests

## Manual verification
After deployment, sign in as `christchurch.admin@plannerdemo.com` and verify `/api/config/init` returns the Christchurch configuration.

Closes #94
